### PR TITLE
test: add e2e test for iam

### DIFF
--- a/javascript/sdk/.env.test
+++ b/javascript/sdk/.env.test
@@ -1,1 +1,1 @@
-VITE_PRELUDE_SERVICE_URL="https://detect.dev.prelude.org"
+VITE_PRELUDE_SERVICE_URL="https://api.developer.prelude.org"

--- a/javascript/sdk/lib/controllers/iam.ts
+++ b/javascript/sdk/lib/controllers/iam.ts
@@ -18,7 +18,7 @@ export default class IAMController {
     handle: string,
     options: RequestOptions = {}
   ): Promise<Credentials> {
-    const response = await this.#client.request("/account", {
+    const response = await this.#client.request("/iam/account", {
       method: "POST",
       body: JSON.stringify({ handle }),
       ...options,
@@ -36,7 +36,7 @@ export default class IAMController {
   }
 
   async getUsers(options: RequestOptions = {}) {
-    const response = await this.#client.requestWithAuth("/account/user", {
+    const response = await this.#client.requestWithAuth("/iam/user", {
       method: "GET",
       ...options,
     });
@@ -49,7 +49,7 @@ export default class IAMController {
     handle: string,
     options: RequestOptions = {}
   ) {
-    const response = await this.#client.requestWithAuth("/account/user", {
+    const response = await this.#client.requestWithAuth("/iam/user", {
       method: "POST",
       body: JSON.stringify({ permission, handle }),
       ...options,
@@ -59,7 +59,7 @@ export default class IAMController {
   }
 
   async deleteUser(handle: string, options: RequestOptions = {}) {
-    await this.#client.requestWithAuth("/account/user", {
+    await this.#client.requestWithAuth("/iam/user", {
       method: "DELETE",
       body: JSON.stringify({ handle }),
       ...options,
@@ -69,7 +69,7 @@ export default class IAMController {
   }
 
   async purgeAccount(options: RequestOptions = {}) {
-    const response = await this.#client.requestWithAuth("/account/purge", {
+    const response = await this.#client.requestWithAuth("/iam/account", {
       method: "DELETE",
       ...options,
     });

--- a/javascript/sdk/test/e2e/iam.spec.ts
+++ b/javascript/sdk/test/e2e/iam.spec.ts
@@ -14,25 +14,27 @@ describe("iam", () => {
     service.setCredentials(credentials);
   });
 
-  it("gets an empty list of users for new account", async () => {
+  it("gets a list of users for new account", async () => {
     const users = await service.iam.getUsers();
     expectTypeOf(users).toBeArray();
-    expect(users.length).toEqual(0);
+    expect(users.length).toEqual(1);
   });
 
   const userHandle = "test-user-admin";
+  let userToken = "";
   it("creates an admin user for the account", async () => {
     const user = await service.iam.createUser(Permissions.ADMIN, userHandle);
 
     expectTypeOf(user.token).toBeString();
+    userToken = user.token;
   });
 
   it("gets list of the users containing the admin user", async () => {
     const users = await service.iam.getUsers();
     expectTypeOf(users).toBeArray();
-    expect(users.length).toEqual(1);
+    expect(users.length).toEqual(2);
 
-    expect(users[0]).toEqual({
+    expect(users[1]).toEqual({
       handle: userHandle,
       permission: Permissions.ADMIN,
     });
@@ -43,10 +45,10 @@ describe("iam", () => {
     expect(isDeleted).toEqual(true);
   });
 
-  it("gets an empty user list after delete ", async () => {
+  it("gets user list after delete", async () => {
     const users = await service.iam.getUsers();
     expectTypeOf(users).toBeArray();
-    expect(users.length).toEqual(0);
+    expect(users.length).toEqual(1);
   });
 
   it("updates the account token", async () => {

--- a/javascript/sdk/test/e2e/iam.spec.ts
+++ b/javascript/sdk/test/e2e/iam.spec.ts
@@ -1,4 +1,3 @@
-import * as uuid from "uuid";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { Permissions, Service } from "../../lib/main";
 
@@ -21,12 +20,10 @@ describe("iam", () => {
   });
 
   const userHandle = "test-user-admin";
-  let userToken = "";
   it("creates an admin user for the account", async () => {
     const user = await service.iam.createUser(Permissions.ADMIN, userHandle);
 
     expectTypeOf(user.token).toBeString();
-    userToken = user.token;
   });
 
   it("gets list of the users containing the admin user", async () => {

--- a/javascript/sdk/test/e2e/iam.spec.ts
+++ b/javascript/sdk/test/e2e/iam.spec.ts
@@ -51,18 +51,6 @@ describe("iam", () => {
     expect(users.length).toEqual(1);
   });
 
-  it("updates the account token", async () => {
-    const oldCreds = service.credentials!;
-    const newToken = uuid.v4();
-    await service.iam.updateToken(newToken);
-
-    await expect(service.iam.getUsers()).rejects.toThrowError("Unauthorized");
-
-    service.setCredentials({ ...oldCreds, token: newToken });
-
-    expectTypeOf(await service.iam.getUsers()).toBeArray();
-  });
-
   it("purges the account", async () => {
     const message = await service.iam.purgeAccount();
     expectTypeOf(message).toBeString();

--- a/javascript/sdk/test/e2e/iam.spec.ts
+++ b/javascript/sdk/test/e2e/iam.spec.ts
@@ -1,0 +1,68 @@
+import * as uuid from "uuid";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { Permissions, Service } from "../../lib/main";
+
+const serviceURL = import.meta.env.VITE_PRELUDE_SERVICE_URL;
+
+describe("iam", () => {
+  let service = new Service({ host: serviceURL });
+
+  it("creates a new account", async () => {
+    const credentials = await service.iam.newAccount("internal-test-iam");
+    expectTypeOf(credentials.account).toBeString();
+    expectTypeOf(credentials.token).toBeString();
+    service.setCredentials(credentials);
+  });
+
+  it("gets an empty list of users for new account", async () => {
+    const users = await service.iam.getUsers();
+    expectTypeOf(users).toBeArray();
+    expect(users.length).toEqual(0);
+  });
+
+  const userHandle = "test-user-admin";
+  it("creates an admin user for the account", async () => {
+    const user = await service.iam.createUser(Permissions.ADMIN, userHandle);
+
+    expectTypeOf(user.token).toBeString();
+  });
+
+  it("gets list of the users containing the admin user", async () => {
+    const users = await service.iam.getUsers();
+    expectTypeOf(users).toBeArray();
+    expect(users.length).toEqual(1);
+
+    expect(users[0]).toEqual({
+      handle: userHandle,
+      permission: Permissions.ADMIN,
+    });
+  });
+
+  it("deletes the admin user from account", async () => {
+    const isDeleted = await service.iam.deleteUser(userHandle);
+    expect(isDeleted).toEqual(true);
+  });
+
+  it("gets an empty user list after delete ", async () => {
+    const users = await service.iam.getUsers();
+    expectTypeOf(users).toBeArray();
+    expect(users.length).toEqual(0);
+  });
+
+  it("updates the account token", async () => {
+    const oldCreds = service.credentials!;
+    const newToken = uuid.v4();
+    await service.iam.updateToken(newToken);
+
+    await expect(service.iam.getUsers()).rejects.toThrowError("Unauthorized");
+
+    service.setCredentials({ ...oldCreds, token: newToken });
+
+    expectTypeOf(await service.iam.getUsers()).toBeArray();
+  });
+
+  it("purges the account", async () => {
+    const message = await service.iam.purgeAccount();
+    expectTypeOf(message).toBeString();
+  });
+});


### PR DESCRIPTION
### Description

This PR adds the e2e tests for the IAM routes in the javascript SDK. It blocks #152
