### PR TITLE
windows 10 fix

### DIFF
--- a/shell/probe/demo.ps1
+++ b/shell/probe/demo.ps1
@@ -98,6 +98,8 @@ Write-Host "Starting test at: $(Get-Date -UFormat %T)
 Start-Sleep -Seconds 3
 CheckRelevance
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 Write-Host "-----------------------------------------------------------------------------------------------------------
 [1] Downloading test"
 DownloadTest
@@ -113,7 +115,6 @@ Write-Host "--------------------------------------------------------------------
 "
 Start-Sleep -Seconds 3
 $cleanresult = ExecuteCleanup
-Remove-Item $TempFile -Force
 
 $Status = ($testresult, $cleanresult | Measure-Object -Maximum).Maximum
 PostResults $Status


### PR DESCRIPTION
I was getting the following error:
` Invoke-WebRequest : The request was aborted: Could not create SSL/TLS secure channel. `

SO on this error: by default powershell uses TLS 1.0 the site security requires TLS 1.2