### PR TITLE
 handling windows defender in demo & raindrop

### DIFF
--- a/shell/probe/demo.ps1
+++ b/shell/probe/demo.ps1
@@ -39,7 +39,7 @@ function DownloadTest {
 function ExecuteTest {
     try {
         $p = Start-Process -FilePath $TempFile -Wait -NoNewWindow -PassThru
-        if ($p.ExitCode -eq 100 ) {
+        if ($p.ExitCode -in 100,9,17,18,105,127 ) {
             Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Result: control test passed"
         } else {
             Write-Host -ForegroundColor Red "`r`n[!] Result: control test failed"

--- a/shell/probe/demo.ps1
+++ b/shell/probe/demo.ps1
@@ -38,38 +38,40 @@ function DownloadTest {
 
 function ExecuteTest {
     try {
-        & $TempFile
-        if ($LASTEXITCODE -eq 100 ) {
+        $p = Start-Process -FilePath $TempFile -Wait -NoNewWindow -PassThru
+        if ($p.ExitCode -eq 100 ) {
             Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Result: control test passed"
         } else {
             Write-Host -ForegroundColor Red "`r`n[!] Result: control test failed"
         }
-        return $LASTEXITCODE
-    } catch [System.Management.Automation.ApplicationFailedException] {
+        return $p.ExitCode
+    } catch [System.InvalidOperationException] {
         Write-Host -ForegroundColor Red $_
         Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Result: control test passed"
         return 127
     } catch {
-        Write-Host -ForegroundColor Red "`r`n[!] Unexpected error occurred:"
+        Write-Host -ForegroundColor Red "`r`n[!] Unexpected error occurred:`r`n"
         Write-Host -ForegroundColor Red  $_
         return 1
     }
+
 }
 
 function ExecuteCleanup {
     try {
-        & $TempFile clean
+        $p = Start-Process -FilePath $TempFile -ArgumentList "clean" -Wait -NoNewWindow -PassThru
         Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Clean up is complete"
-        return $LASTEXITCODE
-    } catch [System.Management.Automation.ApplicationFailedException] {
+        return $p.ExitCode
+    } catch [System.InvalidOperationException] {
         Write-Host -ForegroundColor Red $_
         Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Clean up is complete"
         return 127
     } catch {
-        Write-Host -ForegroundColor Red "`r`n[!] Unexpected error occurred:"
+        Write-Host -ForegroundColor Red "`r`n[!] Unexpected error occurred:`r`n"
         Write-Host -ForegroundColor Red  $_
         return 1
     }
+
 }
 
 function PostResults {

--- a/shell/probe/demo.ps1
+++ b/shell/probe/demo.ps1
@@ -94,7 +94,6 @@ function InstallProbe {
     $account_id = Read-Host -Prompt "Enter your Prelude Account ID"
     $account_token = Read-Host -Prompt "Enter your Prelude Account token"
     & $temp $account_id $account_token
-    Remove-Item $TempFile -Force
 }
 
 Write-Host "

--- a/shell/probe/demo.ps1
+++ b/shell/probe/demo.ps1
@@ -60,7 +60,11 @@ function ExecuteTest {
 function ExecuteCleanup {
     try {
         $p = Start-Process -FilePath $TempFile -ArgumentList "clean" -Wait -NoNewWindow -PassThru
-        Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Clean up is complete"
+        if ($p.ExitCode -eq 100 ) {
+            Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Clean up is complete"
+        } else {
+            Write-Host -ForegroundColor Red "`r`n[!] Clean up failed"
+        }
         return $p.ExitCode
     } catch [System.InvalidOperationException] {
         Write-Host -ForegroundColor Red $_
@@ -153,12 +157,14 @@ Write-Host "
 ###########################################################################################################
 "
 
-if ($Status -in 100,127 ) {
-    Write-Host "[$($symbols.CHECKMARK)] Good job! Your computer detected and responded to a malicious Office document dropped on the disk" -ForegroundColor Green
-} else {
-    Write-Host "[!] This test was able to verify the existence of this vulnerability on your machine, as well as drop a malicious
+if ($Status -in 100,9,17,18,105,127 ) {
+    Write-Host -ForegroundColor Green "[$($symbols.CHECKMARK)] Good job! Your computer detected and responded to a malicious Office document dropped on the disk"
+} elseif ($Status -eq 101) {
+    Write-Host -ForegroundColor Red "[!] This test was able to verify the existence of this vulnerability on your machine, as well as drop a malicious
 Office document on the disk. If you have security controls in place that you suspect should have protected your
-host, please review the logs" -ForegroundColor Red
+host, please review the logs"
+} else {
+    Write-Host -ForegroundColor Red "[!] This test encountered an unexpected error during execution. Please try again"
 }
 
 Write-Host "

--- a/shell/probe/demo.ps1
+++ b/shell/probe/demo.ps1
@@ -54,7 +54,6 @@ function ExecuteTest {
         Write-Host -ForegroundColor Red  $_
         return 1
     }
-
 }
 
 function ExecuteCleanup {
@@ -65,17 +64,13 @@ function ExecuteCleanup {
         } else {
             Write-Host -ForegroundColor Red "`r`n[!] Clean up failed"
         }
-        return $p.ExitCode
     } catch [System.InvalidOperationException] {
         Write-Host -ForegroundColor Red $_
         Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Clean up is complete"
-        return 127
     } catch {
         Write-Host -ForegroundColor Red "`r`n[!] Unexpected error occurred:`r`n"
         Write-Host -ForegroundColor Red  $_
-        return 1
     }
-
 }
 
 function PostResults {
@@ -142,24 +137,23 @@ Write-Host "--------------------------------------------------------------------
 [2] Executing test
 "
 Start-Sleep -Seconds 3
-$testresult = ExecuteTest
+$TestResult = ExecuteTest
 
 Write-Host "-----------------------------------------------------------------------------------------------------------
 [3] Running cleanup
 "
 Start-Sleep -Seconds 3
-$cleanresult = ExecuteCleanup
+ExecuteCleanup
 
-$Status = ($testresult, $cleanresult | Measure-Object -Maximum).Maximum
-PostResults $Status
+PostResults $TestResult
 
 Write-Host "
 ###########################################################################################################
 "
 
-if ($Status -in 100,9,17,18,105,127 ) {
+if ($TestResult -in 100,9,17,18,105,127 ) {
     Write-Host -ForegroundColor Green "[$($symbols.CHECKMARK)] Good job! Your computer detected and responded to a malicious Office document dropped on the disk"
-} elseif ($Status -eq 101) {
+} elseif ($TestResult -eq 101) {
     Write-Host -ForegroundColor Red "[!] This test was able to verify the existence of this vulnerability on your machine, as well as drop a malicious
 Office document on the disk. If you have security controls in place that you suspect should have protected your
 host, please review the logs"

--- a/shell/probe/demo.ps1
+++ b/shell/probe/demo.ps1
@@ -66,7 +66,7 @@ function ExecuteCleanup {
         }
     } catch [System.InvalidOperationException] {
         Write-Host -ForegroundColor Red $_
-        Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Clean up is complete"
+        Write-Host -ForegroundColor Red "`r`n[!] Clean up failed"
     } catch {
         Write-Host -ForegroundColor Red "`r`n[!] Unexpected error occurred:`r`n"
         Write-Host -ForegroundColor Red  $_
@@ -142,7 +142,11 @@ Write-Host "--------------------------------------------------------------------
 [3] Running cleanup
 "
 Start-Sleep -Seconds 3
-ExecuteCleanup
+if ($TestResult -eq 127) {
+    Write-Host -ForegroundColor Green "`r`n[$($symbols.CHECKMARK)] Clean up is complete"
+} else {
+    ExecuteCleanup
+}
 
 PostResults $TestResult
 

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -24,15 +24,23 @@ function Run {
         return
     }
 
-    & $TempFile
-    $TestExit = $LASTEXITCODE
-    & $TempFile clean
-    $CleanExit = $LASTEXITCODE
-
-    $Status = $Test + ":" + ($TestExit, $CleanExit | Measure-Object -Maximum).Maximum
+    $TestExit = Execute $TempFile
+    Start-Process -FilePath $TempFile -ArgumentList "clean" -Wait -NoNewWindow -PassThru
 
     Remove-Item $TempFile -Force
-    Run -Dat $Status
+    Run -Dat $($Test + ":" + $TestExit)
+}
+
+function Execute { 
+    Param([String]$File)
+    try {
+        return (Start-Process -FilePath $File -Wait -NoNewWindow -PassThru).ExitCode
+    } catch [System.InvalidOperationException] {
+        return 127
+    } catch {
+        Write-Host $_
+        return 1
+    }
 }
 
 $Address = if ($Env:PRELUDE_API) { $Env:PRELUDE_API } else { "https://api.preludesecurity.com/" }


### PR DESCRIPTION
PR wraps our VST invocation in a try/catch to catch when the file fails to run b/c Defender prevents it

`ApplicationFailedException` is thrown when Defender prevents the test from running - I'm not sure if this exception is also thrown for other reasons though. There's no good documentation on what throws this. If we want to be certain, we could do string parsing of the exception message, but there's always a risk to error message changes IMO

Example of output with this code:
![Screen Shot 2023-01-18 at 9 44 03 PM](https://user-images.githubusercontent.com/9056078/213364921-cdbb66dd-ca2f-45be-a82b-4886b5643f4f.png)
