### PR TITLE
specify TLS protocol

### DIFF
--- a/shell/probe/demo.ps1
+++ b/shell/probe/demo.ps1
@@ -4,6 +4,7 @@ param(
     [String]$preludeToken
 )
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $PRELUDE_API=if ($Env:PRELUDE_API) { $Env:PRELUDE_API } else { "https://api.preludesecurity.com" }
 $TEST_ID="b74ad239-2ddd-4b1e-b608-8397a43c7c54"
 
@@ -105,8 +106,6 @@ Write-Host "Starting test at: $(Get-Date -UFormat %T)
 [0] Conducting relevance test"
 Start-Sleep -Seconds 3
 CheckRelevance
-
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Write-Host "-----------------------------------------------------------------------------------------------------------
 [1] Downloading test"

--- a/shell/probe/install.ps1
+++ b/shell/probe/install.ps1
@@ -10,6 +10,7 @@ param(
   [String]$endpointId=$env:computername
 )
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $PRELUDE_API=if ($Env:PRELUDE_API) { $Env:PRELUDE_API } else { "https://api.preludesecurity.com" }
 
 function LogError {

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -35,6 +35,7 @@ function Run {
     Run -Dat $Status
 }
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $Address = if ($Env:PRELUDE_API) { $Env:PRELUDE_API } else { "https://api.preludesecurity.com/" }
 $Token = if ($Env:PRELUDE_TOKEN) { $Env:PRELUDE_TOKEN } else { "" }
 $CA = if ($Env:PRELUDE_CA) { $Env:PRELUDE_CA } else { "" }


### PR DESCRIPTION
solves this error: `The request was aborted: Could not create SSL/TLS secure channel.`

By default powershell uses TLS 1.0 and looks like we require TLS 1.2