### PR TITLE
default no tags

### DIFF
--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -34,13 +34,13 @@ def detect(ctx):
 
 
 @detect.command('create-endpoint')
-@click.option('--tags', help='a comma-separated list of tags for this endpoint', default='', type=str)
+@click.option('--tags', help='a comma-separated list of tags for this endpoint', type=str)
 @click.argument('name')
 @click.pass_obj
 @handle_api_error
-def register_endpoint(controller, name, tags=''):
+def register_endpoint(controller, name, tags):
     """ Register a new endpoint """
-    endpoint_token = controller.register_endpoint(name=name, tags=tags.split(','))
+    endpoint_token = controller.register_endpoint(name=name, tags=tags.split(',') if tags else [])
     click.secho(f'Endpoint token: {endpoint_token}', fg=Colors.GREEN.value)
 
 


### PR DESCRIPTION
problem: create-endpoint currently defaulting to empty tag

```

  {
    "endpoint_id": "drip",
    "tags": [
      ""
    ],
    "updated": "2023-01-24 15:44:12.461269"
  },

```