### PR TITLE
move UNKNOWN to not be last

### DIFF
--- a/python/sdk/prelude_sdk/models/codes.py
+++ b/python/sdk/prelude_sdk/models/codes.py
@@ -9,12 +9,12 @@ class Colors(Enum):
 
 @unique
 class RunCode(Enum):
+    UNKNOWN = -1
     DEBUG = 0
     DAILY = 1
     WEEKLY = 2
     MONTHLY = 3
     ONCE = 4
-    UNKNOWN = -1
 
     @classmethod
     def _missing_(cls, value):
@@ -22,11 +22,11 @@ class RunCode(Enum):
 
 @unique
 class Permission(Enum):
+    UNKNOWN = -1
     ADMIN = 0
     EXECUTIVE = 1
     BUILD = 2
     SERVICE = 3
-    UNKNOWN = -1
 
     @classmethod
     def _missing_(cls, value):


### PR DESCRIPTION
we `create-user` with the lowest permission by default, which relies on our permissions list being ordered
`default=[p.name for p in Permission][-1]`'

moving UNKNOWN to the top of the list so that SERVICE is the "lowest" permission 