### PR TITLE
Always post status to slack

### DIFF
--- a/.github/actions/hades/action.yml
+++ b/.github/actions/hades/action.yml
@@ -52,6 +52,7 @@ runs:
         aws s3 cp hades_windows-x86_64 s3://${{ inputs.s3_bucket }}/prelude/probes/hades/
       
     - name: Send custom JSON data to Slack workflow
+      if: always()
       id: slack
       uses: slackapi/slack-github-action@v1.23.0
       with:

--- a/.github/actions/moonlight/action.yml
+++ b/.github/actions/moonlight/action.yml
@@ -45,6 +45,7 @@ runs:
         aws s3 cp swift/probe/moonlight_darwin-arm64 s3://${{ inputs.s3_bucket }}/prelude/probes/moonlight/moonlight_darwin-arm64
 
     - name: Send custom JSON data to Slack workflow
+      if: always()
       id: slack
       uses: slackapi/slack-github-action@v1.23.0
       with:

--- a/.github/actions/presto/action.yml
+++ b/.github/actions/presto/action.yml
@@ -39,6 +39,7 @@ runs:
         aws s3 cp python/probe/presto.py s3://${{ inputs.s3_bucket }}/prelude/probes/presto/presto_windows-x86_64
 
     - name: Send custom JSON data to Slack workflow
+      if: always()
       id: slack
       uses: slackapi/slack-github-action@v1.23.0
       with:

--- a/.github/actions/shell_probes/action.yml
+++ b/.github/actions/shell_probes/action.yml
@@ -54,6 +54,7 @@ runs:
         aws s3 cp shell/probe/raindrop.ps1 s3://${{ inputs.s3_bucket }}/prelude/probes/raindrop/raindrop_windows-x86_64
 
     - name: Send custom JSON data to Slack workflow
+      if: always()
       id: slack
       uses: slackapi/slack-github-action@v1.23.0
       with:


### PR DESCRIPTION
When a step fails in a job, the job stops running in github actions. This means we were not notified for deploy failures. This pr makes sure the notification still comes out (it will say deploy failed)