### PR TITLE
Run with the right domain-target

### DIFF
--- a/shell/probe/install.sh
+++ b/shell/probe/install.sh
@@ -108,9 +108,8 @@ install_darwin_plist () {
     </dict>
 </plist>
 EOF
-    local uid=$(id -u $USER)
-    launchctl bootout gui/$uid $_plist_file_path 2>/dev/null
-    sudo launchctl bootstrap gui/$uid $_plist_file_path
+    sudo launchctl bootout system $_plist_file_path 2>/dev/null
+    sudo launchctl bootstrap system $_plist_file_path
 }
 
 install_darwin() {


### PR DESCRIPTION
Fixes the following error by running as system

<img width="487" alt="image" src="https://user-images.githubusercontent.com/7014725/217120508-758461d3-68d3-425c-a212-79edb8270e01.png">
