### PR TITLE
Autocomplete for profile

### DIFF
--- a/python/cli/prelude_cli/cli.py
+++ b/python/cli/prelude_cli/cli.py
@@ -7,7 +7,7 @@ from prelude_sdk.models.account import Account
 
 
 def complete_profile(ctx, param, incomplete):
-    return [x for x in Account().read_keychain_config()]
+    return [x for x in Account().read_keychain_config() if x.startswith(incomplete)]
 
 
 @click.group()

--- a/python/cli/prelude_cli/cli.py
+++ b/python/cli/prelude_cli/cli.py
@@ -6,10 +6,14 @@ from prelude_cli.views.detect import detect
 from prelude_sdk.models.account import Account
 
 
+def complete_profile(ctx, param, incomplete):
+    return [x for x in Account().read_keychain_config()]
+
+
 @click.group()
 @click.version_option()
 @click.pass_context
-@click.option('--profile', default='default', help='The prelude keychain profile to use', show_default=True)
+@click.option('--profile', default='default', help='The prelude keychain profile to use', show_default=True, shell_complete=complete_profile)
 def cli(ctx, profile):
     ctx.obj = Account(profile=profile)
 


### PR DESCRIPTION
Auto complete hint for --profile in the cli. If you add `eval "$(_PRELUDE_COMPLETE=bash_source prelude)"` to your bash profile, you will be able to tab 
complete your configured profiles. 
