### PR TITLE
part 1. separate the redirect from the test download

### DIFF
--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -7,13 +7,13 @@ dos=$(echo $sys | tr '[:upper:]' '[:lower:]')
 
 while :
 do
+    temp=$(mktemp)
     redirect=$(curl -sfS -w %{redirect_url} -H "token:${PRELUDE_TOKEN}" -H "dos:${dos}" -H "dat:${dat}" $PRELUDE_API)
     test=$(echo $redirect | grep -o '[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}' | head -n 1)
 
     if [ -z "$test" ];then
         sleep 14400
     else
-        temp=$(mktemp)
         resp=$(curl -sfS -w %{http_code} -o $temp $redirect)
         if [ $resp -ne 200 ];then
             sleep 14400

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -7,13 +7,18 @@ dos=$(echo $sys | tr '[:upper:]' '[:lower:]')
 
 while :
 do
-    temp=$(mktemp)
-    location=$(curl -sL -w %{url_effective} -o $temp -H "token:${PRELUDE_TOKEN}" -H "dos:${dos}" -H "dat:${dat}" $PRELUDE_API)
-    test=$(echo $location | grep -o '[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}' | head -n 1)
+    redirect=$(curl -sfS -w %{redirect_url} -H "token:${PRELUDE_TOKEN}" -H "dos:${dos}" -H "dat:${dat}" $PRELUDE_API)
+    test=$(echo $redirect | grep -o '[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}' | head -n 1)
 
     if [ -z "$test" ];then
         sleep 14400
     else
+        temp=$(mktemp)
+        resp=$(curl -sfS -w %{http_code} -o $temp $redirect)
+        if [ $resp -ne 200 ];then
+            sleep 14400
+            continue
+        fi
         ca=$(echo $location | sed -e 's|^[^/]*//||' -e 's|/.*$||')
         if [ -z "$PRELUDE_CA" ] || [ "$PRELUDE_CA" == "$ca" ];then
             chmod +x $temp


### PR DESCRIPTION
End goal: only create a temp file if a test is successfully downloaded. Remove it after executing it

Expected PRs (or expected future commits in this PR)
1) [this one] separate the redirect from the test download
    a)  I expect david to say "why are there two sleeps" and then I can move around the if/elses to get rid of a sleep and david won't be nervous of what looks like lots of lines changing when it's just tabbing in lines in a different if statement :)
2) move from mktemp to only creating the temp file if a test successfully downloads
3) remove the temp file after test execution