### PR TITLE
dont die on empty string tag

### DIFF
--- a/python/cli/prelude_cli/views/interactive.py
+++ b/python/cli/prelude_cli/views/interactive.py
@@ -305,6 +305,7 @@ class AddSchedule:
 
         menu = TerminalMenu(
             {tag for probe in self.wiz.detect.list_endpoints() for tag in probe['tags']},
+            skip_empty_entries=True,
             multi_select=True,
             show_multi_select_hint=True,
             multi_select_select_on_accept=False,


### PR DESCRIPTION
corner case where the long term solution is to not allow a tag that is an empty string and to delete any current tags that are empty string. but this is a bandaid in the meantime for the corner case