### PR TITLE
add plaintext option

### DIFF
--- a/python/cli/prelude_cli/cli.py
+++ b/python/cli/prelude_cli/cli.py
@@ -12,9 +12,10 @@ from prelude_cli.views.interactive import interactive as interactive_command
 @click.version_option()
 @click.pass_context
 @click.option('--profile', default='default', help='The prelude keychain profile to use', show_default=True)
+@click.option('--plaintext/--no-plaintext', default=False, help='Strip out non-essential output')
 @click.option('--interactive', help='Open interactive wizard (cannot be used with a subcommand)', default=False, is_flag=True)
-def cli(ctx, profile, interactive):
-    ctx.obj = Account(profile=profile)
+def cli(ctx, profile, plaintext, interactive):
+    ctx.obj = dict(account=Account(profile=profile), plaintext=plaintext)
     if ctx.invoked_subcommand is None:
         if interactive:
             ctx.invoke(interactive_command)

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -19,7 +19,7 @@ UUID = re.compile('[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a
 @click.pass_context
 def build(ctx):
     """ Custom security tests """
-    ctx.obj = BuildController(account=ctx.obj)
+    ctx.obj = BuildController(**ctx.obj)
 
 
 @build.command('test')

--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -12,7 +12,7 @@ from prelude_sdk.controllers.detect_controller import DetectController
 @click.pass_context
 def detect(ctx):
     """ Continuous security testing """
-    ctx.obj = DetectController(account=ctx.obj)
+    ctx.obj = DetectController(**ctx.obj)
 
 
 @detect.command('create-endpoint')

--- a/python/cli/prelude_cli/views/iam.py
+++ b/python/cli/prelude_cli/views/iam.py
@@ -12,7 +12,7 @@ from prelude_sdk.controllers.iam_controller import IAMController
 @click.pass_context
 def iam(ctx):
     """ Prelude account management """
-    ctx.obj = IAMController(account=ctx.obj)
+    ctx.obj = IAMController(**ctx.obj)
 
 
 @iam.command('create-account')

--- a/python/sdk/prelude_sdk/controllers/build_controller.py
+++ b/python/sdk/prelude_sdk/controllers/build_controller.py
@@ -6,13 +6,14 @@ from prelude_sdk.models.account import verify_credentials
 
 class BuildController:
 
-    def __init__(self, account):
+    def __init__(self, account, plaintext):
         self.account = account
+        self.plaintext = plaintext
 
     @verify_credentials
     def create_test(self, test_id, name):
         """ Create or update a test """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             data = dict(name=name)
             res = requests.post(f'{self.account.hq}/build/tests/{test_id}', json=data, headers=self.account.headers)
             if not res.status_code == 200:
@@ -21,7 +22,7 @@ class BuildController:
     @verify_credentials
     def delete_test(self, test_id):
         """ Delete an existing test """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.delete(f'{self.account.hq}/build/tests/{test_id}', headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)
@@ -29,7 +30,7 @@ class BuildController:
     @verify_credentials
     def get_test(self, test_id):
         """ Get properties of an existing test """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.get(f'{self.account.hq}/build/tests/{test_id}', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -38,7 +39,7 @@ class BuildController:
     @verify_credentials
     def download(self, test_id, filename):
         """ Clone a test file or attachment"""
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.get(f'{self.account.hq}/build/tests/{test_id}/{filename}', headers=self.account.headers)
             if res.status_code == 200:
                 return res.content
@@ -47,7 +48,7 @@ class BuildController:
     @verify_credentials
     def upload(self, test_id, filename, code):
         """ Upload a test or attachment """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.post(f'{self.account.hq}/build/tests/{test_id}/{filename}', json=dict(code=code), headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)
@@ -55,7 +56,7 @@ class BuildController:
     @verify_credentials
     def map(self, test_id: str, x: str):
         """ Add a classification property to a test """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.post(f'{self.account.hq}/build/tests/{test_id}/map/{x}', json=dict(id=test_id), headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)
@@ -63,7 +64,7 @@ class BuildController:
     @verify_credentials
     def unmap(self, test_id: str, x: str):
         """ Remove a classification property from a test """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.delete(f'{self.account.hq}/build/tests/{test_id}/map/{x}', json=dict(id=test_id), headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)

--- a/python/sdk/prelude_sdk/controllers/build_controller.py
+++ b/python/sdk/prelude_sdk/controllers/build_controller.py
@@ -13,7 +13,7 @@ class BuildController:
     @verify_credentials
     def create_test(self, test_id, name):
         """ Create or update a test """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             data = dict(name=name)
             res = requests.post(f'{self.account.hq}/build/tests/{test_id}', json=data, headers=self.account.headers)
             if not res.status_code == 200:
@@ -22,7 +22,7 @@ class BuildController:
     @verify_credentials
     def delete_test(self, test_id):
         """ Delete an existing test """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.delete(f'{self.account.hq}/build/tests/{test_id}', headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)
@@ -30,7 +30,7 @@ class BuildController:
     @verify_credentials
     def get_test(self, test_id):
         """ Get properties of an existing test """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.get(f'{self.account.hq}/build/tests/{test_id}', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -39,7 +39,7 @@ class BuildController:
     @verify_credentials
     def download(self, test_id, filename):
         """ Clone a test file or attachment"""
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.get(f'{self.account.hq}/build/tests/{test_id}/{filename}', headers=self.account.headers)
             if res.status_code == 200:
                 return res.content
@@ -48,7 +48,7 @@ class BuildController:
     @verify_credentials
     def upload(self, test_id, filename, code):
         """ Upload a test or attachment """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.post(f'{self.account.hq}/build/tests/{test_id}/{filename}', json=dict(code=code), headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)
@@ -56,7 +56,7 @@ class BuildController:
     @verify_credentials
     def map(self, test_id: str, x: str):
         """ Add a classification property to a test """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.post(f'{self.account.hq}/build/tests/{test_id}/map/{x}', json=dict(id=test_id), headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)
@@ -64,7 +64,7 @@ class BuildController:
     @verify_credentials
     def unmap(self, test_id: str, x: str):
         """ Remove a classification property from a test """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.delete(f'{self.account.hq}/build/tests/{test_id}/map/{x}', json=dict(id=test_id), headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -13,7 +13,7 @@ class DetectController:
     @verify_credentials
     def register_endpoint(self, name, tags):
         """ Register (or re-register) an endpoint to your account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             params = dict(id=name, tags=tags)
             res = requests.post(f'{self.account.hq}/detect/endpoint', headers=self.account.headers, json=params)
             if res.status_code == 200:
@@ -23,7 +23,7 @@ class DetectController:
     @verify_credentials
     def delete_endpoint(self, ident: str):
         """ Delete an endpoint from your account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             params = dict(id=ident)
             res = requests.delete(f'{self.account.hq}/detect/endpoint', headers=self.account.headers, json=params)
             if res.status_code != 200:
@@ -32,7 +32,7 @@ class DetectController:
     @verify_credentials
     def list_endpoints(self):
         """ List all endpoints on your account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.get(f'{self.account.hq}/detect/endpoint', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -41,7 +41,7 @@ class DetectController:
     @verify_credentials
     def describe_activity(self, filters: dict, view: str = 'logs'):
         """ Get report for an Account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             params = dict(view=view, **filters)
             res = requests.get(f'{self.account.hq}/detect/activity', headers=self.account.headers, params=params)
             if res.status_code == 200:
@@ -50,7 +50,7 @@ class DetectController:
 
     @verify_credentials
     def list_queue(self):
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.get(f'{self.account.hq}/detect/queue', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -59,7 +59,7 @@ class DetectController:
     @verify_credentials
     def list_tests(self):
         """ List all tests available to an account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.get(f'{self.account.hq}/detect/tests', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -68,7 +68,7 @@ class DetectController:
     @verify_credentials
     def enable_test(self, ident: str, run_code: int, tags: str):
         """ Enable a test so endpoints will start running it """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.post(
                 url=f'{self.account.hq}/detect/queue/{ident}',
                 headers=self.account.headers,
@@ -80,7 +80,7 @@ class DetectController:
     @verify_credentials
     def disable_test(self, ident):
         """ Disable a test so endpoints will stop running it """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.delete(f'{self.account.hq}/detect/queue/{ident}', headers=self.account.headers)
             if res.status_code != 200:
                 raise Exception(res.text)
@@ -88,7 +88,7 @@ class DetectController:
     @verify_credentials
     def search(self, identifier: str):
         """ Search the NVD for a keyword """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             params = dict(identifier=identifier)
             res = requests.get(f'{self.account.hq}/detect/search', headers=self.account.headers, params=params)
             if res.status_code == 200:
@@ -98,7 +98,7 @@ class DetectController:
     @verify_credentials
     def social_stats(self, ident: str, days: int = 30):
         """ Pull social statistics for a specific test """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             params = dict(days=days)
             res = requests.get(f'{self.account.hq}/detect/{ident}/social', headers=self.account.headers, params=params)
             if res.status_code == 200:
@@ -108,7 +108,7 @@ class DetectController:
     @verify_credentials
     def recommendations(self):
         """ List all security recommendations for your account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.get(f'{self.account.hq}/detect/recommendations', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -117,7 +117,7 @@ class DetectController:
     @verify_credentials
     def create_recommendation(self, title: str, description: str):
         """ Create a new security recommendation """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             params = dict(title=title, description=description)
             res = requests.post(f'{self.account.hq}/detect/recommendations', headers=self.account.headers, json=params)
             if res.status_code != 200:

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -6,13 +6,14 @@ from prelude_sdk.models.account import verify_credentials
 
 class DetectController:
 
-    def __init__(self, account):
+    def __init__(self, account, plaintext):
         self.account = account
+        self.plaintext = plaintext
 
     @verify_credentials
     def register_endpoint(self, name, tags):
         """ Register (or re-register) an endpoint to your account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             params = dict(id=name, tags=tags)
             res = requests.post(f'{self.account.hq}/detect/endpoint', headers=self.account.headers, json=params)
             if res.status_code == 200:
@@ -22,7 +23,7 @@ class DetectController:
     @verify_credentials
     def delete_endpoint(self, ident: str):
         """ Delete an endpoint from your account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             params = dict(id=ident)
             res = requests.delete(f'{self.account.hq}/detect/endpoint', headers=self.account.headers, json=params)
             if res.status_code != 200:
@@ -31,7 +32,7 @@ class DetectController:
     @verify_credentials
     def list_endpoints(self):
         """ List all endpoints on your account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.get(f'{self.account.hq}/detect/endpoint', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -40,7 +41,7 @@ class DetectController:
     @verify_credentials
     def describe_activity(self, filters: dict, view: str = 'logs'):
         """ Get report for an Account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             params = dict(view=view, **filters)
             res = requests.get(f'{self.account.hq}/detect/activity', headers=self.account.headers, params=params)
             if res.status_code == 200:
@@ -49,7 +50,7 @@ class DetectController:
 
     @verify_credentials
     def list_queue(self):
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.get(f'{self.account.hq}/detect/queue', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -58,7 +59,7 @@ class DetectController:
     @verify_credentials
     def list_tests(self):
         """ List all tests available to an account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.get(f'{self.account.hq}/detect/tests', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -67,7 +68,7 @@ class DetectController:
     @verify_credentials
     def enable_test(self, ident: str, run_code: int, tags: str):
         """ Enable a test so endpoints will start running it """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.post(
                 url=f'{self.account.hq}/detect/queue/{ident}',
                 headers=self.account.headers,
@@ -79,7 +80,7 @@ class DetectController:
     @verify_credentials
     def disable_test(self, ident):
         """ Disable a test so endpoints will stop running it """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.delete(f'{self.account.hq}/detect/queue/{ident}', headers=self.account.headers)
             if res.status_code != 200:
                 raise Exception(res.text)
@@ -87,7 +88,7 @@ class DetectController:
     @verify_credentials
     def search(self, identifier: str):
         """ Search the NVD for a keyword """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             params = dict(identifier=identifier)
             res = requests.get(f'{self.account.hq}/detect/search', headers=self.account.headers, params=params)
             if res.status_code == 200:
@@ -97,7 +98,7 @@ class DetectController:
     @verify_credentials
     def social_stats(self, ident: str, days: int = 30):
         """ Pull social statistics for a specific test """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             params = dict(days=days)
             res = requests.get(f'{self.account.hq}/detect/{ident}/social', headers=self.account.headers, params=params)
             if res.status_code == 200:
@@ -107,7 +108,7 @@ class DetectController:
     @verify_credentials
     def recommendations(self):
         """ List all security recommendations for your account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.get(f'{self.account.hq}/detect/recommendations', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -116,7 +117,7 @@ class DetectController:
     @verify_credentials
     def create_recommendation(self, title: str, description: str):
         """ Create a new security recommendation """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             params = dict(title=title, description=description)
             res = requests.post(f'{self.account.hq}/detect/recommendations', headers=self.account.headers, json=params)
             if res.status_code != 200:

--- a/python/sdk/prelude_sdk/controllers/iam_controller.py
+++ b/python/sdk/prelude_sdk/controllers/iam_controller.py
@@ -13,7 +13,7 @@ class IAMController:
 
     @verify_credentials
     def new_account(self, handle):
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.post(url=f'{self.account.hq}/iam/account', json=dict(handle=handle), headers=self.account.headers)
             if res.status_code != 200:
                 raise Exception(res.text)
@@ -27,7 +27,7 @@ class IAMController:
     @verify_credentials
     def purge_account(self):
         """ Delete an account and all things in it """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.delete(f'{self.account.hq}/iam/account', headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)
@@ -36,7 +36,7 @@ class IAMController:
     @verify_credentials
     def get_account(self):
         """ Get account properties """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.get(f'{self.account.hq}/iam/account', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -45,7 +45,7 @@ class IAMController:
     @verify_credentials
     def create_user(self, permission: int, handle: str, expires: datetime):
         """ Create a new user inside an account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.post(
                 url=f'{self.account.hq}/iam/user',
                 json=dict(permission=permission, handle=handle, expires=expires.isoformat()),
@@ -58,7 +58,7 @@ class IAMController:
     @verify_credentials
     def delete_user(self, handle):
         """ Delete a user from an account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.delete(f'{self.account.hq}/iam/user', json=dict(handle=handle), headers=self.account.headers)
             if res.status_code == 200:
                 return True
@@ -67,7 +67,7 @@ class IAMController:
     @verify_credentials
     def attach_control(self, name: str, api: str, user: str, secret: str = ''):
         """ Attach a control to your Detect account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             params = dict(name=name, api=api, user=user, secret=secret)
             res = requests.post(f'{self.account.hq}/iam/control', headers=self.account.headers, json=params)
             if res.status_code == 200:
@@ -77,7 +77,7 @@ class IAMController:
     @verify_credentials
     def detach_control(self, name: str):
         """ Detach a control from your Detect account """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             params = dict(name=name)
             res = requests.delete(f'{self.account.hq}/iam/control', headers=self.account.headers, json=params)
             if res.status_code == 200:

--- a/python/sdk/prelude_sdk/controllers/iam_controller.py
+++ b/python/sdk/prelude_sdk/controllers/iam_controller.py
@@ -7,12 +7,13 @@ from prelude_sdk.models.account import verify_credentials
 
 class IAMController:
 
-    def __init__(self, account):
+    def __init__(self, account, plaintext):
         self.account = account
+        self.plaintext = plaintext
 
     @verify_credentials
     def new_account(self, handle):
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.post(url=f'{self.account.hq}/iam/account', json=dict(handle=handle), headers=self.account.headers)
             if res.status_code != 200:
                 raise Exception(res.text)
@@ -26,7 +27,7 @@ class IAMController:
     @verify_credentials
     def purge_account(self):
         """ Delete an account and all things in it """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.delete(f'{self.account.hq}/iam/account', headers=self.account.headers)
             if not res.status_code == 200:
                 raise Exception(res.text)
@@ -35,7 +36,7 @@ class IAMController:
     @verify_credentials
     def get_account(self):
         """ Get account properties """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.get(f'{self.account.hq}/iam/account', headers=self.account.headers)
             if res.status_code == 200:
                 return res.json()
@@ -44,7 +45,7 @@ class IAMController:
     @verify_credentials
     def create_user(self, permission: int, handle: str, expires: datetime):
         """ Create a new user inside an account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.post(
                 url=f'{self.account.hq}/iam/user',
                 json=dict(permission=permission, handle=handle, expires=expires.isoformat()),
@@ -57,7 +58,7 @@ class IAMController:
     @verify_credentials
     def delete_user(self, handle):
         """ Delete a user from an account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.delete(f'{self.account.hq}/iam/user', json=dict(handle=handle), headers=self.account.headers)
             if res.status_code == 200:
                 return True
@@ -66,7 +67,7 @@ class IAMController:
     @verify_credentials
     def attach_control(self, name: str, api: str, user: str, secret: str = ''):
         """ Attach a control to your Detect account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             params = dict(name=name, api=api, user=user, secret=secret)
             res = requests.post(f'{self.account.hq}/iam/control', headers=self.account.headers, json=params)
             if res.status_code == 200:
@@ -76,7 +77,7 @@ class IAMController:
     @verify_credentials
     def detach_control(self, name: str):
         """ Detach a control from your Detect account """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             params = dict(name=name)
             res = requests.delete(f'{self.account.hq}/iam/control', headers=self.account.headers, json=params)
             if res.status_code == 200:

--- a/python/sdk/prelude_sdk/controllers/probe_controller.py
+++ b/python/sdk/prelude_sdk/controllers/probe_controller.py
@@ -11,7 +11,7 @@ class ProbeController:
 
     def download(self, name: str, dos: str):
         """ Download a probe executable """
-        with Spinner(plaintext=self.plaintext):
+        with Spinner(self.plaintext):
             res = requests.get(f'{self.account.hq}/download/{name}', headers=dict(dos=dos))
             if not res.status_code == 200:
                 raise Exception(res.text)

--- a/python/sdk/prelude_sdk/controllers/probe_controller.py
+++ b/python/sdk/prelude_sdk/controllers/probe_controller.py
@@ -5,12 +5,13 @@ from prelude_sdk.spinner import Spinner
 
 class ProbeController:
 
-    def __init__(self, account):
+    def __init__(self, account, plaintext):
         self.account = account
+        self.plaintext = plaintext
 
     def download(self, name: str, dos: str):
         """ Download a probe executable """
-        with Spinner():
+        with Spinner(plaintext=self.plaintext):
             res = requests.get(f'{self.account.hq}/download/{name}', headers=dict(dos=dos))
             if not res.status_code == 200:
                 raise Exception(res.text)

--- a/python/sdk/prelude_sdk/spinner.py
+++ b/python/sdk/prelude_sdk/spinner.py
@@ -6,13 +6,15 @@ import threading
 class Spinner:
     busy = False
     delay = 0.1
+    plaintext = False
 
     @staticmethod
     def spinning_cursor():
         while 1: 
             for cursor in '|/-\\': yield cursor
 
-    def __init__(self, delay=None):
+    def __init__(self, delay=None, plaintext=False):
+        self.plaintext = plaintext
         self.spinner_generator = self.spinning_cursor()
         if delay and float(delay): self.delay = delay
 
@@ -25,8 +27,9 @@ class Spinner:
             sys.stdout.flush()
 
     def __enter__(self):
-        self.busy = True
-        threading.Thread(target=self.spinner_task).start()
+        if not self.plaintext:
+            self.busy = True
+            threading.Thread(target=self.spinner_task).start()
 
     def __exit__(self, exception, value, tb):
         self.busy = False

--- a/python/sdk/prelude_sdk/spinner.py
+++ b/python/sdk/prelude_sdk/spinner.py
@@ -13,7 +13,7 @@ class Spinner:
         while 1: 
             for cursor in '|/-\\': yield cursor
 
-    def __init__(self, delay=None, plaintext=False):
+    def __init__(self, plaintext=False, delay=None):
         self.plaintext = plaintext
         self.spinner_generator = self.spinning_cursor()
         if delay and float(delay): self.delay = delay


### PR DESCRIPTION
so everyone can have their precious jq
```
(venv) mahinakaholokula@Mahinas-MacBook-Pro my-prelude % prelude --plaintext detect activity -d 1 | jq
[
  {
    "id": "3645c6a7-7df8-4682-b0e6-ecc3bc9c0ecc",
    "date": "2023-02-28 19:24:50.008086",
    "test": "39de298a-911d-4a3b-aed4-1e8281010a9a",
    "endpoint_id": "beech",
    "status": 100,
    "dos": "linux-x86_64",
    "tags": [
      "tag1"
    ]
  }
]

```