### PR TITLE
Matching edr_id type on ProbeActivity

### DIFF
--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -86,7 +86,7 @@ export interface EnableTest {
 
 export interface Probe {
   endpoint_id: string;
-  edr_id: string;
+  edr_id: string | null;
   host: string;
   last_beacon: string;
   serial_num: string;


### PR DESCRIPTION
Might need this for a ticket I'm pushing up. This just matches the fact that there's an edr_id in ProbeActivity with string | null. Happy to hear your objections.