### PR TITLE
remove start and finish on describeActivity

### DIFF
--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -172,9 +172,9 @@ export default class DetectController {
     options: RequestOptions = {}
   ) {
     const searchParams = new URLSearchParams();
-    searchParams.set("start", query.start);
-    searchParams.set("finish", query.finish);
     searchParams.set("view", query.view);
+    if (query.start) searchParams.set("start", query.start);
+    if (query.finish) searchParams.set("finish", query.finish);
     if (query.tests) searchParams.set("tests", query.tests);
     if (query.tags) searchParams.set("tags", query.tags);
     if (query.endpoints) searchParams.set("endpoints", query.endpoints);

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -202,8 +202,8 @@ export interface RuleInfo {
 export type Stats = Record<Platform, Record<`${ExitCode}`, number>>;
 
 export interface ActivityQuery {
-  start: string;
-  finish: string;
+  start?: string;
+  finish?: string;
   tests?: string;
   result_id?: string;
   endpoints?: string;

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "0.9.57",
+  "version": "0.9.58",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
Per mahina and Francis, the BE will populate these fields for us thus leaving it to be optional.