### PR TITLE
fix: have python parse arrow keys/etc correctly

### DIFF
--- a/python/cli/setup.cfg
+++ b/python/cli/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     click
     rich
     simple-term-menu
+    readline
 [options.entry_points]
 console_scripts =
     prelude = prelude_cli.cli:cli


### PR DESCRIPTION
fixes: https://github.com/preludeorg/libraries/issues/458

* the `readline` import holds the magic that allows line editing (ex. cursor moves back a char instead of typing `^[[A`)
* `Prompt.ask()` was a little funky with `readline` so moved to normal `input`