### PR TITLE
gnureadline not readline

### DIFF
--- a/python/cli/setup.cfg
+++ b/python/cli/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     click
     rich
     simple-term-menu
-    readline
+    gnureadline
 [options.entry_points]
 console_scripts =
     prelude = prelude_cli.cli:cli


### PR DESCRIPTION
per pypi: "It has been renamed to GNUREADLINE to resolve a name clash with the standard library module. "