### PR TITLE
update disable_test to take tags: python sdk, cli, interactive, tests

### DIFF
--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -46,19 +46,20 @@ def list_tests(controller):
               type=click.Choice([r.name for r in RunCode], case_sensitive=False))
 @click.pass_obj
 @handle_api_error
-def activate_test(controller, test, run_code, tags):
+def enable_test(controller, test, run_code, tags):
     """ Add test to your queue """
     controller.enable_test(ident=test, run_code=RunCode[run_code.upper()].value, tags=tags)
 
 
 @detect.command('disable-test')
 @click.argument('test')
+@click.option('-t', '--tags', help='only disable for these tags (comma-separated list)', type=str, default='')
 @click.confirmation_option(prompt='Are you sure?')
 @click.pass_obj
 @handle_api_error
-def deactivate_test(controller, test):
+def disable_test(controller, test, tags):
     """ Remove test from your queue """
-    controller.disable_test(ident=test)
+    controller.disable_test(ident=test, tags=tags)
 
 
 @detect.command('social-stats')

--- a/python/cli/prelude_cli/views/interactive.py
+++ b/python/cli/prelude_cli/views/interactive.py
@@ -293,19 +293,19 @@ class DescheduleTest:
         self.wiz = wiz
 
     def enter(self):
-        menu = TerminalMenu(
-            set([self.wiz.convert(entry['test']) for entry in self.wiz.detect.list_queue()]),
+        queue = self.wiz.detect.list_queue()
+        menu = [f'{self.wiz.normalize(self.wiz.convert(q["test"]), 50)} tag: {self.wiz.normalize(q["tag"], 20)}' for q in queue]
+        indexes = TerminalMenu(
+            menu,
             multi_select=True,
             show_multi_select_hint=True,
             multi_select_select_on_accept=False,
             multi_select_empty_ok=True
-        )
-        menu.show()
+        ).show()
 
-        tests = {self.wiz.convert(i, reverse=True): i for i in list(menu.chosen_menu_entries)}
-        for test_id in tests:
-            print(f'Test [{tests[test_id]}] has been descheduled')
-            self.wiz.detect.disable_test(ident=test_id)
+        for i in indexes:
+            self.wiz.detect.disable_test(ident=queue[i]['test'], tags=queue[i]['tag'])
+            print(f'Test has been descheduled: [{menu[i]}]')
 
 
 class Schedule:

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -109,12 +109,13 @@ class DetectController:
                 raise Exception(res.text)
 
     @verify_credentials
-    def disable_test(self, ident):
+    def disable_test(self, ident: str, tags: str):
         """ Disable a test so endpoints will stop running it """
         with Spinner():
             res = requests.delete(
                 f'{self.account.hq}/detect/queue/{ident}',
                 headers=self.account.headers,
+                params=dict(tags=tags),
                 timeout=10
             )
             if res.status_code != 200:

--- a/python/sdk/tests/test_detect_controller.py
+++ b/python/sdk/tests/test_detect_controller.py
@@ -67,7 +67,7 @@ class TestDetectController:
 
     def test_disable_test(self, unwrap):
         """Test disable_test method"""
-        unwrap(self.detect.disable_test)(self.detect, ident=pytest.test_id)
+        unwrap(self.detect.disable_test)(self.detect, ident=pytest.test_id, tags=self.tags)
         res = unwrap(self.detect.list_queue)(self.detect)
         assert len([test for test in res if test['test'] == pytest.test_id]) == 0
 


### PR DESCRIPTION
Interactive disable test menu looks like:
![Screenshot 2023-04-18 at 9 11 01 AM](https://user-images.githubusercontent.com/9056078/232838252-c69914ec-c1b4-4739-a3df-9609276b236b.png)


Tests pass (staging):
![Screenshot 2023-04-18 at 9 10 15 AM](https://user-images.githubusercontent.com/9056078/232838056-0a4539f8-bf4e-462a-a88b-9f10ead59089.png)
