### PR TITLE
py-sdk fix: dont type the list

### DIFF
--- a/python/sdk/prelude_sdk/controllers/partner_controller.py
+++ b/python/sdk/prelude_sdk/controllers/partner_controller.py
@@ -25,7 +25,7 @@ class PartnerController:
             raise Exception(res.text)
 
     @verify_credentials
-    def deploy(self, partner_name: str, host_ids: list[str]):
+    def deploy(self, partner_name: str, host_ids: list):
         """ Deploy probes on all specified partner endpoints """
         with Spinner():
             params = dict(host_ids=host_ids)


### PR DESCRIPTION
error:

```
    def deploy(self, partner_name: str, host_ids: list[str]):
TypeError: 'type' object is not subscriptable
```