### PR TITLE
Update day object typing: date to datetime

### DIFF
--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -225,7 +225,7 @@ export interface ActivityQuery {
 
 export interface DayResult {
   count: number;
-  date: string;
+  datetime: string;
   failed: number;
 }
 

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This PR reverts back the typing of the day objects date key to date time to match what the BE is sending.