### PR TITLE
make js sdk UploadTest test more robust

### DIFF
--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -125,8 +125,7 @@ describe("SDK Test", () => {
       data = data.replace("$CREATED", new Date().toISOString());
       await service.build.upload(testId, templateName, data);
       const test = await service.detect.getTest(testId);
-      expect(test.attachments).to.have.lengthOf(1);
-      expect(test.attachments[0]).to.be.equal(templateName);
+      expect(test.attachments).toEqual(expect.arrayContaining([templateName]));
     });
 
     it("deleteTest should not throw an error", async () => {


### PR DESCRIPTION
upload might not have length 1 if compute uploads the compiled binaries fast enough