### PR TITLE
raindrop: cache handle to set ExitCode

### DIFF
--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -4,8 +4,9 @@ function Execute {
     Param([String]$File)
 
     try {
-        $R = (Start-Process -FilePath $File -Wait -NoNewWindow -PassThru).ExitCode
-        $Code = if (Test-Path $File) {$R} Else {127}
+        $R = Start-Process -FilePath $File -Wait -NoNewWindow -PassThru
+        $handle = $R.Handle
+        $Code = if (Test-Path $File) {$R.ExitCode} Else {127}
         return $Code
     } catch [System.UnauthorizedAccessException] {
         return 126


### PR DESCRIPTION
re: https://detectors.atlassian.net/browse/DET-308

**Will this work?** idk, i haven't been able to repro the empty ExitCode

**Will this break current probe behavior?** No

**What's the theory?** (From [this SO](https://stackoverflow.com/a/23797762))
> The implementation of the ExitCode property first checks if the process has exited. For some reason, the code that performs that check not only looks at the HasExited property but also verifies that the process handle is present in the process object and throws an exception if it is not. PowerShell intercepts that exception and returns null. 

**What's this fix?** (From the same SO)
> Accessing the Handle property causes the process object to retrieve the process handle and store it internally

**Alternatives?** 
- in the probe (or in BE), swap out empty exit codes for "1"s (or somethin else) and let the probe move to the next test
- keep returning errors to the probe (we can quiet our CW logs) and have the probe go to sleep
