### PR TITLE
hardcode PRELUDE_DIR

### DIFF
--- a/shell/demo/demo.ps1
+++ b/shell/demo/demo.ps1
@@ -7,7 +7,7 @@ param(
 $ProgressPreference = 'SilentlyContinue'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $PRELUDE_API = if ($env:PRELUDE_API) { $env:PRELUDE_API } else { "https://api.preludesecurity.com" };
-$PRELUDE_DIR = if ($env:PRELUDE_DIR) { $env:PRELUDE_DIR } else { ".vst" };
+$PRELUDE_DIR = ".vst";
 $DOS = "windows-x86_64"
 $PROTECTED = @(0,9,15,100,104,105,106,107,126,127,137)
 


### PR DESCRIPTION
re: https://detectors.atlassian.net/browse/DET-374

I believe the issue is that the installer sets PRELUDE_DIR and also restricts access to it. So if you run the installer and then run demo after that, you (the normal user) wont have access to PRELUDE_DIR anymore

If we need to keep letting users override the `.vst` dir for demo runs, we can also change the name of the env variable to `PRELUDE_DEMO_DIR` or something