### PR TITLE
bump SDK version for new createTest changes

### DIFF
--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
Necessary for NPM JS publish and the reason is based on the removal of published param for createTest and removal of it from Test object