### PR TITLE
Updating python and JS sdk tests

### DIFF
--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -194,18 +194,23 @@ describe("SDK Test", () => {
       activeTest = testId;
     });
 
-    it("download should return the same data as the upload", async () => {
-      const file = readFileSync(`${__dirname}/templates/template.go`, "utf8");
-      let data = file.toString();
-      data = data.replace("$ID", testId);
-      data = data.replace("$NAME", testName);
-      data = data.replace("$UNIT", testUnit);
-      data = data.replace("$CREATED", new Date().toISOString());
-      await service.build.upload(testId, templateName, data);
-      const download = await service.detect.download(testId, templateName);
-      expect(download).toContain(testId);
-      expect(download).toContain(testName);
-    });
+    it(
+      "download should return the same data as the upload",
+      async () => {
+        const file = readFileSync(`${__dirname}/templates/template.go`, "utf8");
+        let data = file.toString();
+        data = data.replace("$ID", testId);
+        data = data.replace("$NAME", testName);
+        data = data.replace("$UNIT", testUnit);
+        data = data.replace("$CREATED", new Date().toISOString());
+        await service.build.upload(testId, templateName, data);
+        await sleep(5000);
+        const download = await service.detect.download(testId, templateName);
+        expect(download).toContain(testId);
+        expect(download).toContain(testName);
+      },
+      { timeout: 10_000 }
+    );
 
     it("enableTest should add a new test to the queue", async function () {
       await service.detect.enableTest({
@@ -245,15 +250,6 @@ describe("SDK Test", () => {
       endpointId = result[0].endpoint_id;
     });
 
-    it("updateEndpoint should return an endpoint with updated tags", async () => {
-      await service.detect.updateEndpoint({
-        endpoint_id: endpointId,
-        tags: updatedTags,
-      });
-      const result = await service.detect.listEndpoints();
-      expect(result[0].tags[0]).eq(updatedTags);
-    });
-
     describe("with probe", () => {
       afterAll(async () => {
         unlinkSync(`${probeName}.sh`);
@@ -291,7 +287,7 @@ describe("SDK Test", () => {
             });
           });
         },
-        { timeout: 30_000 }
+        { timeout: 10_000 }
       );
 
       it(
@@ -307,6 +303,15 @@ describe("SDK Test", () => {
         },
         { retry: 5 }
       );
+    });
+
+    it("updateEndpoint should return an endpoint with updated tags", async () => {
+      await service.detect.updateEndpoint({
+        endpoint_id: endpointId,
+        tags: updatedTags,
+      });
+      const result = await service.detect.listEndpoints();
+      expect(result[0].tags[0]).eq(updatedTags);
     });
 
     it("socialStats should return an object with a non-empty array of values", async function () {

--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -97,6 +97,7 @@ describe("SDK Test", () => {
   describe("Build Controller", async () => {
     const testId = randomUUID();
     const testName = "test";
+    const updatedTestName = "updatedTest";
     const templateName = `${testId}.go`;
     const testUnit = "AV";
 
@@ -113,8 +114,14 @@ describe("SDK Test", () => {
       await service.iam.purgeAccount();
     });
 
-    it("createTest should not throw an error", async () => {
-      await service.build.createTest(testName, testUnit, undefined, testId);
+    it("createTest should return created test", async () => {
+      const response = await service.build.createTest(
+        testName,
+        testUnit,
+        undefined,
+        testId
+      );
+      expect(response.name).eq(testName);
     });
 
     it("upload should have an attachment in the getTest call", async () => {
@@ -129,6 +136,11 @@ describe("SDK Test", () => {
       expect(test.attachments).toEqual(expect.arrayContaining([templateName]));
     });
 
+    it("updateTest should return updated test", async () => {
+      const response = await service.build.updateTest(testId, updatedTestName);
+      expect(response.name).eq(updatedTestName);
+    });
+
     it("deleteTest should not throw an error", async () => {
       await service.build.deleteTest(testId);
     });
@@ -139,6 +151,7 @@ describe("SDK Test", () => {
     const serial = "test_serial";
     const edrId = "test_edr_id";
     const tags = "test_tag";
+    const updatedTags = "updated_test_tag";
     const healthCheck = "39de298a-911d-4a3b-aed4-1e8281010a9a";
     let endpointToken = "";
     let endpointId = "";
@@ -230,6 +243,15 @@ describe("SDK Test", () => {
       expect(result).toHaveLength(1);
       expect(result[0].host).eq(hostName);
       endpointId = result[0].endpoint_id;
+    });
+
+    it("updateEndpoint should return an endpoint with updated tags", async () => {
+      await service.detect.updateEndpoint({
+        endpoint_id: endpointId,
+        tags: updatedTags,
+      });
+      const result = await service.detect.listEndpoints();
+      expect(result[0].tags[0]).eq(updatedTags);
     });
 
     describe("with probe", () => {

--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -114,7 +114,7 @@ describe("SDK Test", () => {
     });
 
     it("createTest should not throw an error", async () => {
-      await service.build.createTest(testId, testName, testUnit);
+      await service.build.createTest(testName, testUnit, testId);
     });
 
     it("upload should have an attachment in the getTest call", async () => {
@@ -220,7 +220,6 @@ describe("SDK Test", () => {
         serial_num: serial,
         edr_id: edrId,
         tags,
-        endpoint_id: "",
       });
       expect(result).toHaveLength(32);
       endpointToken = result;

--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -114,7 +114,7 @@ describe("SDK Test", () => {
     });
 
     it("createTest should not throw an error", async () => {
-      await service.build.createTest(testName, testUnit, testId);
+      await service.build.createTest(testName, testUnit, undefined, testId);
     });
 
     it("upload should have an attachment in the getTest call", async () => {
@@ -174,7 +174,7 @@ describe("SDK Test", () => {
     });
 
     it("getTest should return a test object", async () => {
-      await service.build.createTest(testId, testName, testUnit);
+      await service.build.createTest(testName, testUnit, undefined, testId);
       const test = await service.detect.getTest(testId);
       expect(test).toHaveProperty("attachments");
       expect(test).toHaveProperty("unit");

--- a/python/sdk/tests/templates/template.go
+++ b/python/sdk/tests/templates/template.go
@@ -1,6 +1,7 @@
 /*
 ID: $ID
 NAME: $NAME
+UNIT: $UNIT
 CREATED: $CREATED
 */
 package main
@@ -14,7 +15,7 @@ func test() {
 }
 
 func clean() {
-	Endpoint.Stop(100)
+	println("[+] Cleaning up")
 }
 
 func main() {

--- a/python/sdk/tests/test_build_controller.py
+++ b/python/sdk/tests/test_build_controller.py
@@ -1,4 +1,5 @@
 import os
+import time
 import uuid
 import pytest
 
@@ -16,6 +17,8 @@ class TestBuildController:
         """Setup the test class"""
         self.test_id = str(uuid.uuid4())
         self.test_name = 'test'
+        self.test_updated_name = 'updated_test'
+        self.test_unit = 'AV'
         self.build = BuildController(pytest.account)
         self.detect = DetectController(pytest.account)
 
@@ -30,10 +33,17 @@ class TestBuildController:
         template = files(templates).joinpath('template.go').read_text()
         template = template.replace('$ID', self.test_id)
         template = template.replace('$NAME', self.test_name)
+        template = template.replace('$UNIT', self.test_unit)
         template = template.replace('$CREATED', str(datetime.utcnow()))
         unwrap(self.build.upload)(self.build, test_id=self.test_id, filename=f'{self.test_id}.go', data=template)
+        time.sleep(5)
         res = unwrap(self.detect.get_test)(self.detect, test_id=self.test_id)
         assert f'{self.test_id}.go' in res['attachments']
+
+    def test_update_test(self, unwrap):
+        """Test update_test method"""
+        res = unwrap(self.build.update_test)(self.build, test_id=self.test_id, name=self.test_updated_name)
+        assert res['name'] == self.test_updated_name
 
     @pytest.mark.order(after='test_detect_controller.py::TestDetectController::test_disable_test')
     def test_delete_test(self, unwrap):

--- a/python/sdk/tests/test_detect_controller.py
+++ b/python/sdk/tests/test_detect_controller.py
@@ -18,6 +18,7 @@ class TestDetectController:
         self.serial = 'test_serial'
         self.edr_id = 'test_edr_id'
         self.tags = 'test_tag'
+        self.updated_tags = 'updated_test_tag'
         self.health_check = '39de298a-911d-4a3b-aed4-1e8281010a9a'
         self.recommendation = 'Test'
         self.detect = DetectController(pytest.account)
@@ -87,6 +88,13 @@ class TestDetectController:
             assert len(describe_activity) == 2
         finally:
             os.remove(pytest.probe)
+    
+    @pytest.mark.order(after='test_describe_activity')
+    def test_update_endpoint(self, unwrap):
+        """Test update_endpoint method"""
+        unwrap(self.detect.update_endpoint)(self.detect, endpoint_id=pytest.endpoint_id, tags=self.updated_tags)
+        res = unwrap(self.detect.list_endpoints)(self.detect)
+        assert res[0]['tags'][0] == self.updated_tags
 
     @pytest.mark.order(after='test_describe_activity')
     def test_disable_test(self, unwrap):


### PR DESCRIPTION
- [x] waiting on BE change then should be good to go.
- [x] added new update endpoint/test tests

> all tests are passing except there are still inconsistencies with the probe timing out before both tests can run and describe-activity tests pass 100% of the time. I have seen it pass before on both python and JS today so I would consider it fine just inconsistent.

Update to this ^ @makk94 helped me debug, thank you!, but a solution to the issue that we were facing is that we were not giving compute enough time to handle the test attachments, so adding a 5s sleep did the trick. 
<img width="871" alt="Screenshot 2023-06-06 at 3 54 49 PM" src="https://github.com/preludeorg/libraries/assets/84744117/71057973-5a0d-45df-b011-8e88ed37b258">
<img width="1043" alt="Screenshot 2023-06-06 at 3 53 09 PM" src="https://github.com/preludeorg/libraries/assets/84744117/d0f1b661-4fc8-425e-8e17-05535ddb4cfc">



