### PR TITLE
add metrics view for js sdk

### DIFF
--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -8,6 +8,7 @@ import {
   DisableTest,
   EnableTest,
   Insight,
+  MetricsActivity,
   Probe,
   ProbeActivity,
   RegisterEndpointParams,
@@ -127,8 +128,19 @@ export default class DetectController {
     options?: RequestOptions
   ): Promise<TestActivity[]>;
   async describeActivity(
+    query: ActivityQuery & { view: "metrics" },
+    options?: RequestOptions
+  ): Promise<MetricsActivity[]>;
+  async describeActivity(
     query: ActivityQuery & {
-      view: "days" | "logs" | "insights" | "probes" | "advisories" | "tests";
+      view:
+        | "days"
+        | "logs"
+        | "insights"
+        | "probes"
+        | "advisories"
+        | "tests"
+        | "metrics";
     },
     options: RequestOptions = {}
   ) {

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -300,6 +300,13 @@ export interface ProbeActivity {
   edr_id: string | null;
 }
 
+export interface MetricsActivity {
+  account_id: string;
+  endpoints: number;
+  tests: number;
+  company: string;
+}
+
 export interface CreateRecommendation {
   title: string;
   description: string;

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
this PR adds the metrics view for describeActivity endpoint for the JS SDK, I don't see any changes that need to be made for python and it seems to be supported already