### PR TITLE
add new metric responses

### DIFF
--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -29,6 +29,7 @@ export interface User {
 }
 
 export interface Account {
+  account_id: string;
   whoami: string;
   controls: string[];
   users: User[];
@@ -305,6 +306,9 @@ export interface MetricsActivity {
   endpoints: number;
   tests: number;
   company: string;
+  unique_tests: number;
+  custom_tests: number;
+  tests_by_endpoint_by_day: number;
 }
 
 export interface CreateRecommendation {

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This PR adds the 3 new response values from the metrics view and also adds a missing response value of account_id for the Account object which I found was not being handled properly yesterday ( I didn't know we added that to the response). @makk94 can you double check all these inclusions with BE code please.