### PR TITLE
fix codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 *                   @khyberspache
-/python/*           @stephanwampouille
-/javascript/*       @stephanwampouille
-/python/cli/*       @ceci21
-/go/tests/*         @bfuzzy1
+/python/            @stephanwampouille
+/javascript/        @stephanwampouille
+/python/cli/        @ceci21
+/go/tests/          @bfuzzy1


### PR DESCRIPTION
Github wasn't properly assigned reviewers, I think it had to do with the extra `*`