### PR TITLE
CLI - Upload credentials file (feature proposal)

### DIFF
--- a/python/cli/prelude_cli/views/configure.py
+++ b/python/cli/prelude_cli/views/configure.py
@@ -4,7 +4,7 @@ from configparser import ConfigParser, MissingSectionHeaderError
 
 
 @click.command()
-@click.option('-f', '--file', help="path to credentials file (.ini)", default=None, type=click.Path(exists=True))
+@click.option('-f', '--file', help="path to credentials (.ini) file", default=None, type=click.Path(exists=True))
 @click.pass_obj
 def configure(account, file):
     """ Configure your local keychain """
@@ -15,7 +15,7 @@ def configure(account, file):
 
     if file:
         config = ConfigParser()
-        
+
         try:
             config.read(file)
             profile = config.sections()[0]

--- a/python/cli/prelude_cli/views/configure.py
+++ b/python/cli/prelude_cli/views/configure.py
@@ -1,13 +1,47 @@
 import click
 
+from configparser import ConfigParser, MissingSectionHeaderError
+
 
 @click.command()
+@click.option('-f', '--file', help="path to credentials file (.ini)", default=None, type=click.Path(exists=True))
 @click.pass_obj
-def configure(account):
+def configure(account, file):
     """ Configure your local keychain """
-    profile = click.prompt('Enter the profile name', default=account.profile, show_default=True)
-    hq = click.prompt('Enter the Prelude API', default=account.hq, show_default=True)
-    account_id = click.prompt('Enter your account ID')
-    account_token = click.prompt('Enter your account token')
-    account.configure(account_id=account_id, token=account_token, hq=hq, profile=profile)
+    profile = account.profile
+    hq = account.hq
+    account_id = None
+    account_token = None
+
+    if file:
+        config = ConfigParser()
+        
+        try:
+            config.read(file)
+            profile = config.sections()[0]
+            values = config[profile]
+            hq = values['hq']
+            account_id = values['account']
+            account_token = values['token']
+        except MissingSectionHeaderError:
+            click.secho('Invalid credentials file: No profile header found', fg='red')
+            return
+        except KeyError as e:
+            click.secho('Invalid credentials file: Missing {}'.format(e), fg='red')
+            return
+        except Exception as e:
+            click.secho('Invalid credentials file', fg='red')
+            return
+
+        if not account_id or not account_token:
+            click.secho('Invalid credentials file: Missing values for account ID and/or account token', fg='red')
+            return
+        
+    else:
+        profile = click.prompt('Enter the profile name', default=account.profile, show_default=True)
+        hq = click.prompt('Enter the Prelude API', default=account.hq, show_default=True)
+        account_id = click.prompt('Enter your account ID')
+        account_token = click.prompt('Enter your account token')
+         
+    account.configure(profile=profile, hq=hq, account_id=account_id, token=account_token)
     click.secho('Credentials saved', fg='green')


### PR DESCRIPTION
This PR adds the ability to configure a new account in the CLI by supplying a valid credentials (.ini) file exported from our UI using the optional `--file` parameter, or flag `-f`.

#### Usage:

```
prelude configure -f <file-path>
# or 
prelude configure --flag <file-path>
```

One difference between the current method of configuring the account (entering by line item) and this proposed one is that the configuration file requires the `profile` section header, and `hq`, `account`, and `token` values (throwing an error if keys or values are missing), whereas the line item method has default values set for the `profile` and `hq`.


## Demo / Screenshots
In the demo screenshots below, I aliased `cli` to my local structure while developing-- so `cli` corresponds to `prelude`.

#### Successful usage

<img width="290" alt="Screenshot 2023-06-20 at 7 06 32 PM" src="https://github.com/preludeorg/libraries/assets/10601897/661f31d8-86fc-4962-971c-c5ff5dfa084a">


#### Errors
<img width="678" alt="Screenshot 2023-06-20 at 7 05 16 PM" src="https://github.com/preludeorg/libraries/assets/10601897/80b90024-05c2-4358-a09b-b285d0b0aa69">
<img width="311" alt="Screenshot 2023-06-20 at 7 03 49 PM" src="https://github.com/preludeorg/libraries/assets/10601897/2d56c8eb-b7ba-462f-9928-e22b0a90e7d9">
<img width="478" alt="Screenshot 2023-06-20 at 7 02 56 PM" src="https://github.com/preludeorg/libraries/assets/10601897/6f1e2748-b14f-4aef-81f6-722f5e048bca">
