### PR TITLE
feat(cli) - Add techniques flag to create-test and update-test

### DIFF
--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -26,16 +26,18 @@ def build(ctx):
 @click.argument('name')
 @click.option('-u', '--unit', required=True, help='unit identifier', type=str)
 @click.option('-t', '--test', help='test identifier', default=None, type=str)
+@click.option('-q', '--techniques', help='comma-separated list of valid MITRE ATT&CK codes [e.g. T1557,T1040]', default=None, type=str)
 @click.option('-a', '--advisory', default=None, hidden=True, type=str)
 @click.pass_obj
 @handle_api_error
-def create_test(controller, name, unit, test, advisory):
+def create_test(controller, name, unit, test, techniques, advisory):
     """ Create or update a security test """
     with Spinner():
         t = controller.create_test(
             name=name,
             unit=unit,
             test_id=test,
+            techniques=techniques,
             advisory=advisory
         )
 
@@ -64,16 +66,18 @@ def create_test(controller, name, unit, test, advisory):
 @click.argument('test')
 @click.option('-n', '--name', help='test name', default=None, type=str)
 @click.option('-u', '--unit', help='unit identifier', default=None, type=str)
-@click.option('-a', '--advisory', help='alert identifier [CVE ID, Advisory ID, etc]', default=None, type=str)
+@click.option('-q', '--techniques', help='comma-separated list of valid MITRE ATT&CK codes [e.g. T1557,T1040]', default=None, type=str)
+@click.option('-a', '--advisory', help='alert identifier [CVE ID, Advisory ID, etc]', default=None, hidden=True, type=str)
 @click.pass_obj
 @handle_api_error
-def update_test(controller, test, name, unit, advisory):
+def update_test(controller, test, name, unit, techniques, advisory):
     """ Create or update a security test """
     with Spinner():
         test = controller.update_test(
             test_id=test,
             name=name,
             unit=unit,
+            techniques=techniques,
             advisory=advisory
         )
     print_json(data=test)


### PR DESCRIPTION
NOTE: This PR is awaiting changes for the Python SDK.

This PR:
- updates the CLI to accept an optional `--techniques` or `-q` flag which accepts comma-separated values corresponding to valid MITRE ATT&CK technique codes.
- additionally adds a hidden attribute to the advisory flag for update-test, which was missed while doing #694 

### Usage

#### Create test

```
# can accept a single value
❯ prelude build create-test ... --techniques T1557
❯ prelude build create-test ... -q T1557

# or multiple values
❯ prelude build create-test ... --techniques T1557,T1040
❯ prelude build create-test ... -q T1557,T1040
```

#### Update test
```
# can accept a single value
❯ prelude build update-test ... --techniques T1003
❯ prelude build update-test ... -q T1003

# or multiple values
❯ prelude build update-test ... --techniques T1003,T1539
❯ prelude build update-test ... -q T1003,T1539
```


### Help text

#### Create test
```
❯ prelude build create-test --help
Usage: cli.py build create-test [OPTIONS] NAME

  Create or update a security test

Options:
  -u, --unit TEXT        unit identifier  [required]
  -t, --test TEXT        test identifier
  -q, --techniques TEXT  comma-separated list of valid MITRE ATT&CK codes
                         [e.g. T1557,T1040]
  --help                 Show this message and exit.
```
#### Update test
```
❯ prelude build update-test --help
Usage: cli.py build update-test [OPTIONS] TEST

  Create or update a security test

Options:
  -n, --name TEXT        test name
  -u, --unit TEXT        unit identifier
  -q, --techniques TEXT  comma-separated list of valid MITRE ATT&CK codes
                         [e.g. T1557,T1040]
  --help                 Show this message and exit.
```
