### PR TITLE
Default to bin uploads

### DIFF
--- a/python/sdk/prelude_sdk/controllers/build_controller.py
+++ b/python/sdk/prelude_sdk/controllers/build_controller.py
@@ -64,7 +64,7 @@ class BuildController:
             raise Exception(res.text)
 
     @verify_credentials
-    def upload(self, test_id, filename, data, binary=False):
+    def upload(self, test_id, filename, data, binary=True):
         """ Upload a test or attachment """
         if len(data) > 1000000:
             raise ValueError(f'File size must be under 1MB ({filename})')


### PR DESCRIPTION
Requires a change to API gateway. Essentially, all files we put to the api will be binary encoded (even text). The api gateway will decode them from base64, and the event will have a isBase64 headers set that the service code already deals with. Provided we don't allow uploads over ~8megs in size, we should be good (apigw has a 10 meg limit, base64 encoding is probably ~20 percent size increase).

Why all files? Did you know detecting if a file is binary or text is really hard? https://stackoverflow.com/questions/898669/how-can-i-detect-if-a-file-is-binary-non-text-in-python do you want that in the code base? Or just treat everything slightly less efficiently? 
