### PR TITLE
remove Prelude permission type to match Python

### DIFF
--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -87,7 +87,6 @@ export const Permissions = {
   EXECUTIVE: 1,
   BUILD: 2,
   SERVICE: 3,
-  PRELUDE: 4,
 } as const;
 
 export type Permission = (typeof Permissions)[keyof typeof Permissions];


### PR DESCRIPTION
Sneaking this in before 1.2.13 sdk update