### PR TITLE
bump JS SDK to 1.3.1 for new 110 exit code

### DIFF
--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This is needed for new publish to include 110 exit code