### PR TITLE
Update partner endpoints to use new control codes

### DIFF
--- a/javascript/sdk/lib/controllers/partner.ts
+++ b/javascript/sdk/lib/controllers/partner.ts
@@ -1,6 +1,7 @@
 import Client from "../client";
 import {
   AttachPartnerParams,
+  ControlCode,
   DeployParams,
   EndpointsParams,
   PartnerEndpoints,
@@ -15,23 +16,29 @@ export default class PartnerController {
   }
 
   async attachPartner(
-    { name, api, user, secret = "" }: AttachPartnerParams,
+    { partnerCode, api, user, secret = "" }: AttachPartnerParams,
     options: RequestOptions = {}
   ) {
-    const response = await this.#client.requestWithAuth(`/partner/${name}`, {
-      method: "POST",
-      body: JSON.stringify({ api, user, secret }),
-      ...options,
-    });
+    const response = await this.#client.requestWithAuth(
+      `/partner/${partnerCode}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ api, user, secret }),
+        ...options,
+      }
+    );
 
     return response.text();
   }
 
-  async detachPartner(name: string, options: RequestOptions = {}) {
-    const response = await this.#client.requestWithAuth(`/partner/${name}`, {
-      method: "DELETE",
-      ...options,
-    });
+  async detachPartner(partnerCode: ControlCode, options: RequestOptions = {}) {
+    const response = await this.#client.requestWithAuth(
+      `/partner/${partnerCode}`,
+      {
+        method: "DELETE",
+        ...options,
+      }
+    );
 
     return response.text();
   }
@@ -39,7 +46,7 @@ export default class PartnerController {
   /** Get a list of endpoints from all partners */
   async endpoints(
     {
-      partnerName,
+      partnerCode,
       platform,
       hostname = "",
       offset = 0,
@@ -55,7 +62,7 @@ export default class PartnerController {
     });
 
     const response = await this.#client.requestWithAuth(
-      `/partner/endpoints/${partnerName}?${searchParams.toString()}`,
+      `/partner/endpoints/${partnerCode}?${searchParams.toString()}`,
       {
         method: "GET",
         ...options,
@@ -67,10 +74,10 @@ export default class PartnerController {
 
   /** Deploy probes on all specified partner endpoints */
   async deploy(
-    { partnerName, hostIds }: DeployParams,
+    { partnerCode, hostIds }: DeployParams,
     options: RequestOptions = {}
   ): Promise<void> {
-    await this.#client.requestWithAuth(`/partner/deploy/${partnerName}`, {
+    await this.#client.requestWithAuth(`/partner/deploy/${partnerCode}`, {
       method: "POST",
       body: JSON.stringify({ host_ids: hostIds }),
       ...options,

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -374,14 +374,14 @@ export interface DownloadParams {
 }
 
 export interface AttachPartnerParams {
-  name: string;
+  partnerCode: ControlCode;
   api: string;
   user: string;
   secret?: string;
 }
 
 export interface EndpointsParams {
-  partnerName: string;
+  partnerCode: ControlCode;
   platform: string;
   hostname?: string;
   offset?: number;
@@ -389,7 +389,7 @@ export interface EndpointsParams {
 }
 
 export interface DeployParams {
-  partnerName: string;
+  partnerCode: ControlCode;
   hostIds: string[];
 }
 

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -205,6 +205,16 @@ export const ActionCodes = {
 export type ActionCodeName = keyof typeof ActionCodes;
 export type ActionCode = (typeof ActionCodes)[ActionCodeName];
 
+export const ControlCodes = {
+  INVALID: 0,
+  CROWDSTRIKE: 1,
+  DEFENDER: 2,
+  SPLUNK: 3,
+} as const;
+
+export type ControlCodeName = keyof typeof ControlCodes;
+export type ControlCode = (typeof ControlCodes)[ControlCodeName];
+
 export type Platform =
   | "darwin-arm64"
   | "darwin-x86_64"

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "files": [
     "dist"

--- a/python/sdk/prelude_sdk/controllers/partner_controller.py
+++ b/python/sdk/prelude_sdk/controllers/partner_controller.py
@@ -9,11 +9,11 @@ class PartnerController:
         self.account = account
 
     @verify_credentials
-    def attach(self, name: str, api: str, user: str, secret: str):
+    def attach(self, partner_code: int, api: str, user: str, secret: str):
         """ Attach a partner to your account """
         params = dict(api=api, user=user, secret=secret)
         res = requests.post(
-            f'{self.account.hq}/partner/{name}',
+            f'{self.account.hq}/partner/{partner_code}',
             headers=self.account.headers,
             json=params,
             timeout=10
@@ -23,10 +23,10 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def detach(self, name: str):
+    def detach(self, partner_code: int):
         """ Detach a partner from your Detect account """
         res = requests.delete(
-            f'{self.account.hq}/partner/{name}',
+            f'{self.account.hq}/partner/{partner_code}',
             headers=self.account.headers,
             timeout=10
         )
@@ -35,11 +35,11 @@ class PartnerController:
         raise Exception(res.text)
         
     @verify_credentials
-    def endpoints(self, partner_name: str, platform: str, hostname: str = '', offset: int = 0, count: int = 100):
+    def endpoints(self, partner_code: int, platform: str, hostname: str = '', offset: int = 0, count: int = 100):
         """ Get a list of endpoints from all partners """
         params = dict(platform=platform, hostname=hostname, offset=offset, count=count)
         res = requests.get(
-            f'{self.account.hq}/partner/endpoints/{partner_name}',
+            f'{self.account.hq}/partner/endpoints/{partner_code}',
             headers=self.account.headers,
             params=params,
             timeout=30
@@ -49,11 +49,11 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def deploy(self, partner_name: str, host_ids: list):
+    def deploy(self, partner_code: int, host_ids: list):
         """ Deploy probes on all specified partner endpoints """
         params = dict(host_ids=host_ids)
         res = requests.post(
-            f'{self.account.hq}/partner/deploy/{partner_name}',
+            f'{self.account.hq}/partner/deploy/{partner_code}',
             headers=self.account.headers,
             json=params,
             timeout=30


### PR DESCRIPTION
This PR updates the /partner endpoints to take in a `partner-code` which is an enum value. For example `endpoint/deploy/1`

Thoughts on naming convention @makk94 ? Not sure if I should switch between partner and control