### PR TITLE
JS version bump to 1.3.4

### DIFF
--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This is needed to update the exit codes. I forgot to include it in my other PR