### PR TITLE
update endpoint responses for JS and Python

### DIFF
--- a/javascript/sdk/lib/controllers/build.ts
+++ b/javascript/sdk/lib/controllers/build.ts
@@ -1,5 +1,10 @@
 import Client from "../client";
-import type { RequestOptions, Test } from "../types";
+import type {
+  AttachedTest,
+  RequestOptions,
+  StatusResponse,
+  UploadedAttachment,
+} from "../types";
 
 export default class BuildController {
   #client: Client;
@@ -16,14 +21,14 @@ export default class BuildController {
     advisory?: string,
     testId?: string,
     options: RequestOptions = {}
-  ): Promise<Test> {
+  ): Promise<AttachedTest> {
     const response = await this.#client.requestWithAuth(`/build/tests`, {
       method: "POST",
       body: JSON.stringify({ name, unit, techniques, advisory, id: testId }),
       ...options,
     });
 
-    return await response.json();
+    return (await response.json()) as AttachedTest;
   }
 
   /** Update a test */
@@ -34,7 +39,7 @@ export default class BuildController {
     techniques?: string,
     advisory?: string,
     options: RequestOptions = {}
-  ): Promise<Test> {
+  ): Promise<AttachedTest> {
     const response = await this.#client.requestWithAuth(
       `/build/tests/${testId}`,
       {
@@ -44,18 +49,23 @@ export default class BuildController {
       }
     );
 
-    return await response.json();
+    return (await response.json()) as AttachedTest;
   }
 
   /** Delete an existing test */
   async deleteTest(
     testId: string,
     options: RequestOptions = {}
-  ): Promise<void> {
-    await this.#client.requestWithAuth(`/build/tests/${testId}`, {
-      method: "DELETE",
-      ...options,
-    });
+  ): Promise<StatusResponse> {
+    const response = await this.#client.requestWithAuth(
+      `/build/tests/${testId}`,
+      {
+        method: "DELETE",
+        ...options,
+      }
+    );
+
+    return (await response.json()) as StatusResponse;
   }
 
   /** Upload a test or attachment */
@@ -64,11 +74,16 @@ export default class BuildController {
     filename: string,
     data: BodyInit,
     options: RequestOptions = {}
-  ): Promise<void> {
-    await this.#client.requestWithAuth(`/build/tests/${testId}/${filename}`, {
-      method: "POST",
-      body: data,
-      ...options,
-    });
+  ): Promise<UploadedAttachment> {
+    const response = await this.#client.requestWithAuth(
+      `/build/tests/${testId}/${filename}`,
+      {
+        method: "POST",
+        body: data,
+        ...options,
+      }
+    );
+
+    return (await response.json()) as UploadedAttachment;
   }
 }

--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -41,7 +41,7 @@ export default class DetectController {
       ...options,
     });
 
-    return response.json();
+    return response.text();
   }
 
   /** Update an endpoint in your account */

--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -41,7 +41,7 @@ export default class DetectController {
       ...options,
     });
 
-    return response.text();
+    return response.json();
   }
 
   /** Update an endpoint in your account */
@@ -108,7 +108,7 @@ export default class DetectController {
         ...options,
       }
     );
-    return await response.json();
+    return (await response.json()) as Advisory[];
   }
 
   /** Get logs for an Account */

--- a/javascript/sdk/lib/controllers/partner.ts
+++ b/javascript/sdk/lib/controllers/partner.ts
@@ -1,11 +1,14 @@
 import Client from "../client";
 import {
   AttachPartnerParams,
+  AttachedPartner,
   ControlCode,
   DeployParams,
+  DeployedEndpoints,
   EndpointsParams,
   PartnerEndpoints,
   RequestOptions,
+  StatusResponse,
 } from "../types";
 
 export default class PartnerController {
@@ -18,7 +21,7 @@ export default class PartnerController {
   async attachPartner(
     { partnerCode, api, user, secret = "" }: AttachPartnerParams,
     options: RequestOptions = {}
-  ) {
+  ): Promise<AttachedPartner> {
     const response = await this.#client.requestWithAuth(
       `/partner/${partnerCode}`,
       {
@@ -28,10 +31,13 @@ export default class PartnerController {
       }
     );
 
-    return response.text();
+    return (await response.json()) as AttachedPartner;
   }
 
-  async detachPartner(partnerCode: ControlCode, options: RequestOptions = {}) {
+  async detachPartner(
+    partnerCode: ControlCode,
+    options: RequestOptions = {}
+  ): Promise<StatusResponse> {
     const response = await this.#client.requestWithAuth(
       `/partner/${partnerCode}`,
       {
@@ -40,7 +46,7 @@ export default class PartnerController {
       }
     );
 
-    return response.text();
+    return (await response.json()) as StatusResponse;
   }
 
   /** Get a list of endpoints from all partners */
@@ -76,11 +82,16 @@ export default class PartnerController {
   async deploy(
     { partnerCode, hostIds }: DeployParams,
     options: RequestOptions = {}
-  ): Promise<void> {
-    await this.#client.requestWithAuth(`/partner/deploy/${partnerCode}`, {
-      method: "POST",
-      body: JSON.stringify({ host_ids: hostIds }),
-      ...options,
-    });
+  ): Promise<DeployedEndpoints> {
+    const response = await this.#client.requestWithAuth(
+      `/partner/deploy/${partnerCode}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ host_ids: hostIds }),
+        ...options,
+      }
+    );
+
+    return (await response.json()) as DeployedEndpoints;
   }
 }

--- a/javascript/sdk/lib/controllers/probe.ts
+++ b/javascript/sdk/lib/controllers/probe.ts
@@ -8,8 +8,15 @@ export default class ProbeController {
     this.#client = client;
   }
 
-  /** Download a probe executable */
-  async download({ name, dos }: DownloadParams, options: RequestOptions = {}) {
+  /**
+   * Download a probe executable
+   *
+   * @returns {string} - A URL location to download the probe.
+   */
+  async download(
+    { name, dos }: DownloadParams,
+    options: RequestOptions = {}
+  ): Promise<string> {
     const response = await this.#client.request(`/download/${name}`, {
       method: "GET",
       ...options,

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -435,8 +435,4 @@ export interface AuditLog {
   timestamp: string;
 }
 
-export interface AuditLogValues {
-  name: string;
-  unit: string;
-  id: string;
-}
+export type AuditLogValues = Record<string, unknown>;

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -413,7 +413,7 @@ export interface DeployParams {
 }
 
 export interface DeployedEndpoints {
-  id: string;
+  id: ControlCode;
   host_ids: string[];
 }
 
@@ -431,7 +431,7 @@ export interface AuditLog {
   account_id: string;
   user_id: string;
   values: AuditLogValues;
-  status: ExitCode;
+  status: string;
   timestamp: string;
 }
 

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -13,6 +13,10 @@ export interface Credentials {
 
 export type RequestOptions = Omit<RequestInit, "method" | "body">;
 
+export interface StatusResponse {
+  status: true;
+}
+
 export interface Test {
   account_id: string;
   id: string;
@@ -20,6 +24,15 @@ export interface Test {
   unit: string;
   techniques: string[];
   advisory: string;
+}
+
+export type AttachedTest = Test & {
+  attachments: string[];
+};
+
+export interface UploadedAttachment {
+  id: string;
+  filename: string;
 }
 
 export interface User {
@@ -36,10 +49,10 @@ export interface Control {
 export interface Account {
   account_id: string;
   whoami: string;
-  controls: Control[];
   users: User[];
-  mode: Mode;
   queue: Queue[];
+  controls: Control[];
+  mode: Mode;
   company: string;
 }
 
@@ -119,6 +132,10 @@ export interface EnableTest {
   tags?: string;
 }
 
+export interface EnabledTest {
+  id: string;
+}
+
 export interface DisableTest {
   test: string;
   tags: string;
@@ -126,11 +143,11 @@ export interface DisableTest {
 
 export interface Probe {
   endpoint_id: string;
-  edr_id: string | null;
   host: string;
-  last_beacon: string;
   serial_num: string;
+  edr_id: string | null;
   tags: string[];
+  last_beacon: string;
   created: string;
 }
 
@@ -232,11 +249,6 @@ export interface Activity {
   dos: Platform;
   tags: string[] | null;
   edr_id: string | null;
-}
-
-export interface TestData {
-  attachments: string[];
-  mappings: string[];
 }
 
 export interface TestUsage {
@@ -366,6 +378,10 @@ export interface UpdateEndpointParams {
   tags?: string;
 }
 
+export interface UpdatedEndpoint {
+  id: string;
+}
+
 export interface DownloadParams {
   name: string;
   dos: Platform;
@@ -376,6 +392,11 @@ export interface AttachPartnerParams {
   api: string;
   user: string;
   secret?: string;
+}
+
+export interface AttachedPartner {
+  api: string;
+  connected: boolean;
 }
 
 export interface EndpointsParams {
@@ -391,6 +412,11 @@ export interface DeployParams {
   hostIds: string[];
 }
 
+export interface DeployedEndpoints {
+  id: string;
+  host_ids: string[];
+}
+
 export type PartnerEndpoints = Record<
   string,
   {
@@ -399,3 +425,18 @@ export type PartnerEndpoints = Record<
     state: string;
   }
 >;
+
+export interface AuditLog {
+  name: string;
+  account_id: string;
+  user_id: string;
+  values: AuditLogValues;
+  status: ExitCode;
+  timestamp: string;
+}
+
+export interface AuditLogValues {
+  name: string;
+  unit: string;
+  id: string;
+}

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -427,7 +427,7 @@ export type PartnerEndpoints = Record<
 >;
 
 export interface AuditLog {
-  name: string;
+  event: string;
   account_id: string;
   user_id: string;
   values: AuditLogValues;

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "type": "module",
   "files": [
     "dist"

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -22,7 +22,7 @@ class DetectController:
             timeout=10
         )
         if res.status_code == 200:
-            return res.text
+            return res.json()
         raise Exception(res.text)
 
     @verify_credentials
@@ -135,7 +135,7 @@ class DetectController:
             timeout=10
         )
         if res.status_code == 200:
-            return res.content
+            return res.text
         raise Exception(res.text)
 
     @verify_credentials

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -135,7 +135,7 @@ class DetectController:
             timeout=10
         )
         if res.status_code == 200:
-            return res.text
+            return res.content
         raise Exception(res.text)
 
     @verify_credentials

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -22,7 +22,7 @@ class DetectController:
             timeout=10
         )
         if res.status_code == 200:
-            return res.json()
+            return res.text
         raise Exception(res.text)
 
     @verify_credentials

--- a/python/sdk/prelude_sdk/controllers/partner_controller.py
+++ b/python/sdk/prelude_sdk/controllers/partner_controller.py
@@ -31,7 +31,7 @@ class PartnerController:
             timeout=10
         )
         if res.status_code == 200:
-            return res.text
+            return res.json()
         raise Exception(res.text)
         
     @verify_credentials

--- a/python/sdk/setup.cfg
+++ b/python/sdk/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = prelude-sdk
-version = 1.3.2
+version = 1.3.3
 author = Prelude Research
 author_email = support@preludesecurity.com
 description = For interacting with the Prelude API


### PR DESCRIPTION
This PR updates the responses of multiple endpoints (primarily for JS SDK as we comply with types) following the responses listed [here](https://preludeorg.slack.com/docs/T7GV7S3B4/F05JXGQ2W3C). To recap some changes:

- Adding the test attachments to the test object that gets returned from getTest, createTest, and updateTest
- Update multiple endpoints, primarily those related to deletes, to return a {status:true} response 
- Return the attachment on upload-attachment
- Add type for AuditLog and update endpoint to return that type
- Smaller updates of minor significance on other endpoints and small refactors of code
- Updated tests to work with new responses

Checklist:
- [x] javascript
- [x] javascript tests
- [x] python
- [x] python tests

