### PR TITLE
remove weekly and monthly runcodes

### DIFF
--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -84,8 +84,6 @@ export const RunCodes = {
   INVALID: -1,
   DEBUG: 0,
   DAILY: 1,
-  WEEKLY: 2,
-  MONTHLY: 3,
   MONDAY: 10,
   TUESDAY: 11,
   WEDNESDAY: 12,

--- a/python/sdk/prelude_sdk/models/codes.py
+++ b/python/sdk/prelude_sdk/models/codes.py
@@ -5,8 +5,6 @@ class RunCode(Enum):
     INVALID = -1
     DEBUG = 0
     DAILY = 1
-    WEEKLY = 2
-    MONTHLY = 3
     MONDAY = 10
     TUESDAY = 11
     WEDNESDAY = 12


### PR DESCRIPTION
This PR removes the weekly and monthly run code options. No version bump required as it was handled in https://github.com/preludeorg/libraries/pull/731/