### PR TITLE
JS Version Bump 1.3.7 (exit code changes)

### DIFF
--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This is needed to publish new JS sdk to include exit code changes