### PR TITLE
[det550] update register/update endpoint with control

### DIFF
--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -9,9 +9,9 @@ class DetectController:
         self.account = account
 
     @verify_credentials
-    def register_endpoint(self, host, serial_num, edr_id='', tags=None):
+    def register_endpoint(self, host, serial_num, edr_id='', partner_code=0, tags=None):
         """ Register (or re-register) an endpoint to your account """
-        body = dict(id=f'{host}:{serial_num}:{edr_id}')
+        body = dict(id=f'{host}:{serial_num}:{edr_id}:{partner_code}')
         if tags:
             body['tags'] = tags
 
@@ -26,13 +26,15 @@ class DetectController:
         raise Exception(res.text)
 
     @verify_credentials
-    def update_endpoint(self, endpoint_id, host=None, edr_id=None, tags=None):
+    def update_endpoint(self, endpoint_id, host=None, edr_id='', partner_code=0, tags=None):
         """ Update an endpoint in your account """
         body = dict()
         if host:
             body['host'] = host
-        if edr_id is not None:
+        if edr_id != '':
             body['edr_id'] = edr_id
+        if partner_code != 0:
+            body['control'] = partner_code
         if tags is not None:
             body['tags'] = tags
 


### PR DESCRIPTION
Example: create endpoint:
```
(venv) mahinakaholokula@Mahinas-MacBook-Pro my-prelude % prelude --profile qa-us2 detect create-endpoint -h m -s k -t det550 --partner DEFENDER              
cbfd290ba20de2afb0d168917a646702
(venv) mahinakaholokula@Mahinas-MacBook-Pro my-prelude % prelude --profile qa-us2 detect endpoints
[
  {
    "endpoint_id": "17f85c1f-7675-4d2b-bb92-66d8e236cd8e",
    "host": "m",
    "serial_num": "k",
    "edr_id": null,
    "control": 2,
    "tags": [
      "det550"
    ],
    "last_beacon": "2023-08-01",
    "created": "2023-08-01 23:00:53.785782"
  },
```


Example: update control to None:
```
(venv) mahinakaholokula@Mahinas-MacBook-Pro my-prelude % prelude --profile qa-us2 detect update-endpoint 17f85c1f-7675-4d2b-bb92-66d8e236cd8e --partner None
{
  "id": "17f85c1f-7675-4d2b-bb92-66d8e236cd8e"
}
(venv) mahinakaholokula@Mahinas-MacBook-Pro my-prelude % prelude --profile qa-us2 detect endpoints
[
  {
    "endpoint_id": "17f85c1f-7675-4d2b-bb92-66d8e236cd8e",
    "host": "m",
    "serial_num": "k",
    "edr_id": null,
    "control": null,
    "tags": [],
    "last_beacon": "2023-08-01",
    "created": "2023-08-01 23:00:53.785782"
  },
```