### PR TITLE
Swapping exit code to correct value

### DIFF
--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -176,7 +176,7 @@ export const ExitCodes = {
   FALSE_POSITIVE: 110,
   TEST_DISALLOWED: 126,
   STATIC_QUARANTINE: 127,
-  OUT_OF_MEMORY: 137,
+  BLOCKED: 137,
   UNEXPECTED_ERROR: 256,
 } as const;
 
@@ -191,6 +191,7 @@ export const ExitCodeGroup = {
     ExitCodes.PROTECTED,
     ExitCodes.DYNAMIC_QUARANTINE,
     ExitCodes.BLOCKED_AT_PERIMETER,
+    ExitCodes.BLOCKED,
     ExitCodes.EXPLOIT_PREVENTED,
     ExitCodes.TEST_DISALLOWED,
     ExitCodes.STATIC_QUARANTINE,
@@ -206,7 +207,6 @@ export const ExitCodeGroup = {
     ExitCodes.MALFORMED_TEST,
     ExitCodes.TIMED_OUT,
     ExitCodes.FAILED_CLEANUP,
-    ExitCodes.OUT_OF_MEMORY,
     ExitCodes.UNEXPECTED_ERROR,
   ],
   NOT_RELEVANT: [

--- a/python/sdk/prelude_sdk/models/codes.py
+++ b/python/sdk/prelude_sdk/models/codes.py
@@ -59,7 +59,7 @@ class ExitCode(Enum):
     FALSE_POSITIVE = 110
     TEST_DISALLOWED = 126
     STATIC_QUARANTINE = 127
-    OUT_OF_MEMORY = 137
+    BLOCKED = 137
     UNEXPECTED_ERROR = 256
 
     @classmethod
@@ -98,6 +98,7 @@ class State(Enum):
                 ExitCode.PROTECTED,
                 ExitCode.DYNAMIC_QUARANTINE,
                 ExitCode.BLOCKED_AT_PERIMETER,
+                ExitCode.BLOCKED,
                 ExitCode.EXPLOIT_PREVENTED,
                 ExitCode.TEST_DISALLOWED,
                 ExitCode.STATIC_QUARANTINE,
@@ -113,7 +114,6 @@ class State(Enum):
                 ExitCode.MALFORMED_TEST,
                 ExitCode.TIMED_OUT,
                 ExitCode.FAILED_CLEANUP,
-                ExitCode.OUT_OF_MEMORY,
                 ExitCode.UNEXPECTED_ERROR
             ],
             State.NOT_RELEVANT: [


### PR DESCRIPTION
Reason: 137 means some other process stopped the probe. This would either be a defensive control or, if on a container, the OS indicating that there is not sufficient memory to finish the test. In either case, the endpoint would be protected.