### PR TITLE
remove control & EDR ID from update/register endpoint

### DIFF
--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -5,7 +5,6 @@ import {
   Advisory,
   AdvisoryInfo,
   AttachedTest,
-  ControlCodes,
   DayResult,
   DisableTest,
   EnableTest,
@@ -33,19 +32,13 @@ export default class DetectController {
 
   /** Register (or re-register) an endpoint to your account */
   async registerEndpoint(
-    {
-      host,
-      serial_num,
-      edr_id = "",
-      control = ControlCodes.INVALID,
-      tags,
-    }: RegisterEndpointParams,
+    { host, serial_num, tags }: RegisterEndpointParams,
     options: RequestOptions = {}
   ): Promise<string> {
     const response = await this.#client.requestWithAuth("/detect/endpoint", {
       method: "POST",
       body: JSON.stringify({
-        id: `${host}:${serial_num}:${edr_id}:${control}`,
+        id: `${host}:${serial_num}`,
         tags,
       }),
       ...options,
@@ -56,13 +49,7 @@ export default class DetectController {
 
   /** Update an endpoint in your account */
   async updateEndpoint(
-    {
-      endpoint_id,
-      host,
-      edr_id,
-      control = ControlCodes.INVALID,
-      tags,
-    }: UpdateEndpointParams,
+    { endpoint_id, host, tags }: UpdateEndpointParams,
     options: RequestOptions = {}
   ): Promise<UpdatedEndpoint> {
     const response = await this.#client.requestWithAuth(
@@ -71,8 +58,6 @@ export default class DetectController {
         method: "POST",
         body: JSON.stringify({
           host,
-          edr_id,
-          control,
           tags,
         }),
         ...options,

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -365,16 +365,12 @@ export interface DecideRecommendation {
 export interface RegisterEndpointParams {
   host: string;
   serial_num: string;
-  edr_id?: string;
-  control?: ControlCode;
   tags?: string;
 }
 
 export interface UpdateEndpointParams {
   endpoint_id: string;
   host?: string;
-  edr_id?: string;
-  control?: ControlCode;
   tags?: string;
 }
 

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "files": [
     "dist"

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -9,9 +9,9 @@ class DetectController:
         self.account = account
 
     @verify_credentials
-    def register_endpoint(self, host, serial_num, edr_id='', partner_code=0, tags=None):
+    def register_endpoint(self, host, serial_num, tags=None):
         """ Register (or re-register) an endpoint to your account """
-        body = dict(id=f'{host}:{serial_num}:{edr_id}:{partner_code}')
+        body = dict(id=f'{host}:{serial_num}')
         if tags:
             body['tags'] = tags
 
@@ -26,15 +26,11 @@ class DetectController:
         raise Exception(res.text)
 
     @verify_credentials
-    def update_endpoint(self, endpoint_id, host=None, edr_id=None, partner_code=0, tags=None):
+    def update_endpoint(self, endpoint_id, host=None, tags=None):
         """ Update an endpoint in your account """
         body = dict()
         if host:
             body['host'] = host
-        if edr_id is not None:
-            body['edr_id'] = edr_id or None
-        if partner_code != 0:
-            body['control'] = partner_code
         if tags is not None:
             body['tags'] = tags
 

--- a/python/sdk/tests/test_detect_controller.py
+++ b/python/sdk/tests/test_detect_controller.py
@@ -16,7 +16,6 @@ class TestDetectController:
         """Setup the test class"""
         self.host = 'test_host'
         self.serial = 'test_serial'
-        self.edr_id = 'test_edr_id'
         self.tags = 'test_tag'
         self.updated_tags = 'updated_test_tag'
         self.health_check = '39de298a-911d-4a3b-aed4-1e8281010a9a'
@@ -54,7 +53,7 @@ class TestDetectController:
 
     def test_register_endpoint(self, unwrap):
         """Test register_endpoint method"""
-        res = unwrap(self.detect.register_endpoint)(self.detect, host=self.host, serial_num=self.serial, edr_id=self.edr_id, tags=self.tags)
+        res = unwrap(self.detect.register_endpoint)(self.detect, host=self.host, serial_num=self.serial, tags=self.tags)
         assert len(res) == 32
         pytest.endpoint_token = res
 
@@ -64,7 +63,6 @@ class TestDetectController:
         assert len(res) > 0
         assert self.host == res[0]['host']
         assert self.serial == res[0]['serial_num']
-        assert self.edr_id == res[0]['edr_id']
         assert self.tags in res[0]['tags']
         pytest.endpoint_id = res[0]['endpoint_id']
 


### PR DESCRIPTION
I want to double check that that id in the registerEndpoint is correct. Not sure if the extra `:` was needed to be kept at the end