### PR TITLE
fix: update last_beacon to last_seen and remove debug runcode

### DIFF
--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -82,7 +82,6 @@ export interface Queue {
 
 export const RunCodes = {
   INVALID: -1,
-  DEBUG: 0,
   DAILY: 1,
   MONDAY: 10,
   TUESDAY: 11,
@@ -146,7 +145,7 @@ export interface Probe {
   edr_id: string | null;
   control: ControlCode | null;
   tags: string[];
-  last_beacon: string;
+  last_seen: string;
   created: string;
 }
 

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
Are there any other updates made to the backend recently that I should be aware of to include in this update pr?