### PR TITLE
Chore: use the test ID as the filename when writing to disk

### DIFF
--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -8,18 +8,18 @@ dos=$(uname -s)-$(uname -m)
 
 while :
 do
-    exe=$PRELUDE_DIR/$(head -c10 <(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom 2>/dev/null))
-    location=$(curl -sfL -w %{url_effective} --create-dirs -o $exe -H "token: ${PRELUDE_TOKEN}" -H "dos: ${dos}" -H "dat: ${dat}" -H "version: 1.1" $api)
+    location=$(curl -sfL -w %{url_effective} --create-dirs -o $PRELUDE_DIR/0 -H "token: ${PRELUDE_TOKEN}" -H "dos: ${dos}" -H "dat: ${dat}" -H "version: 1.1" $api)
     test=$(echo $location | grep -o '[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}' | head -n 1)
-    
+
     if [ $test ];then
         ca=$(echo $location | sed -e 's|^[^/]*//||' -e 's|/.*$||')
 
         if [ "$PRELUDE_CA" == "$ca" ];then
-            echo "[P] Running $test [$exe]"
-            chmod +x $exe && $exe
+            echo "[P] Running $test"
+            mv $PRELUDE_DIR/0 $PRELUDE_DIR/$test
+            chmod +x $exe && $PRELUDE_DIR/$test
             code=$?
-            dat="${test}:$([[ -f $exe ]] && echo $code || echo 127)"
+            dat="${test}:$([[ -f $PRELUDE_DIR/$test ]] && echo $code || echo 127)"
         fi
     elif [[ "$location" == *"upgrade"* ]];then
         echo "[P] Upgrade required" && exit 1

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -1,29 +1,28 @@
 #!/bin/bash
 
-PRELUDE_DIR=".vst"
-PRELUDE_CA="prelude-account-us2-us-east-1.s3.amazonaws.com"
+PRELUDE_CA="prelude-account-us1-us-west-1.s3.amazonaws.com"
 
-api="https://api.us2.preludesecurity.com"
+api="https://api.preludesecurity.com"
 dos=$(uname -s)-$(uname -m)
 
 while :
 do
-    redirect=$(curl -sfL -w '%{url_effective}' -H "token: ${PRELUDE_TOKEN}" -H "dos: ${dos}" -H "id:b74ad239-2ddd-4b1e-b608-8397a43c7c54" -H "dat: ${dat}" -H "version: 1.2" $api -o /dev/null)
+    redirect=$(curl -sfL -w '%{url_effective}' -H "token: ${PRELUDE_TOKEN}" -H "dos: ${dos}" -H "dat: ${dat}" -H "version: 1.2" $api -o /dev/null)
     test=$(echo $redirect | grep -o '[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}' | head -n 1)
 
     if [ $test ];then
         ca=$(echo $redirect | sed -e 's|^[^/]*//||' -e 's|/.*$||')
 
         if [ "$PRELUDE_CA" == "$ca" ];then
-            curl -sf --create-dirs -o "$PRELUDE_DIR/$test" $redirect
-            chmod +x $PRELUDE_DIR/$test && $PRELUDE_DIR/$test
+            curl -sf --create-dirs -o .vst/$test $redirect
+            chmod +x .vst/$test && .vst/$test
             code=$?
-            dat="${test}:$([[ -f $PRELUDE_DIR/$test ]] && echo $code || echo 127)"
+            dat="${test}:$([[ -f .vst/$test ]] && echo $code || echo 127)"
         fi
-    elif [[ "$location" == *"upgrade"* ]];then
+    elif [[ "$redirect" == *"upgrade"* ]];then
         echo "[P] Upgrade required" && exit 1
     else
-        rm -rf $PRELUDE_DIR
+        rm -rf .vst
         unset dat
         sleep 14440
     fi

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -20,7 +20,7 @@ do
             dat="${test}:$([[ -f .vst/$test ]] && echo $code || echo 127)"
         fi
     elif [[ "$redirect" == *"upgrade"* ]];then
-        echo "[P] Upgrade required" && exit 1
+        sleep 30 && exit 1
     else
         rm -rf .vst
         unset dat

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -1,30 +1,29 @@
 #!/bin/bash
 
 PRELUDE_DIR=".vst"
-PRELUDE_CA="prelude-account-us1-us-west-1.s3.amazonaws.com"
+PRELUDE_CA="prelude-account-us2-us-east-1.s3.amazonaws.com"
 
-api="https://api.preludesecurity.com"
+api="https://api.us2.preludesecurity.com"
 dos=$(uname -s)-$(uname -m)
 
 while :
 do
-    location=$(curl -sfL -w %{url_effective} --create-dirs -o $PRELUDE_DIR/0 -H "token: ${PRELUDE_TOKEN}" -H "dos: ${dos}" -H "dat: ${dat}" -H "version: 1.1" $api)
-    test=$(echo $location | grep -o '[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}' | head -n 1)
+    redirect=$(curl -sfL -w '%{url_effective}' -H "token: ${PRELUDE_TOKEN}" -H "dos: ${dos}" -H "id:b74ad239-2ddd-4b1e-b608-8397a43c7c54" -H "dat: ${dat}" -H "version: 1.2" $api -o /dev/null)
+    test=$(echo $redirect | grep -o '[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}' | head -n 1)
 
     if [ $test ];then
-        ca=$(echo $location | sed -e 's|^[^/]*//||' -e 's|/.*$||')
+        ca=$(echo $redirect | sed -e 's|^[^/]*//||' -e 's|/.*$||')
 
         if [ "$PRELUDE_CA" == "$ca" ];then
-            echo "[P] Running $test"
-            mv $PRELUDE_DIR/0 $PRELUDE_DIR/$test
-            chmod +x $exe && $PRELUDE_DIR/$test
+            curl -sf --create-dirs -o "$PRELUDE_DIR/$test" $redirect
+            chmod +x $PRELUDE_DIR/$test && $PRELUDE_DIR/$test
             code=$?
             dat="${test}:$([[ -f $PRELUDE_DIR/$test ]] && echo $code || echo 127)"
         fi
     elif [[ "$location" == *"upgrade"* ]];then
         echo "[P] Upgrade required" && exit 1
     else
-        rm -r $PRELUDE_DIR
+        rm -rf $PRELUDE_DIR
         unset dat
         sleep 14440
     fi

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -20,7 +20,7 @@ do
             dat="${test}:$([[ -f .vst/$test ]] && echo $code || echo 127)"
         fi
     elif [[ "$redirect" == *"upgrade"* ]];then
-        sleep 30 && exit 1
+        sleep 30 && exit
     else
         rm -rf .vst
         unset dat

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -31,7 +31,7 @@ while ($true) {
     try {
         $VstDir = New-Item -ItemType Directory -Path ".vst" -Force
         $Headers = @{
-            'token' = "c9bcc556d45abbc4b01113be65bbf43a"
+            'token' = FromEnv "PRELUDE_TOKEN"
             'dos' = $Dos
             'dat' = $Dat
             'version' = "1.2"

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -35,7 +35,7 @@ while ($true) {
             'token' = FromEnv "PRELUDE_TOKEN"
             'dos' = $Dos
             'dat' = $Dat
-            'version' = "1.1"
+            'version' = "1.2"
         }
         $Response = Invoke-WebRequest -URI $Api -UseBasicParsing -Headers $Headers -MaximumRedirection 1 -OutFile $Vst -PassThru
         $Test = $Response.BaseResponse.ResponseUri.AbsolutePath.Split("/")[-1].Split("_")[0]

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -45,7 +45,6 @@ while ($true) {
                 Write-Output "[P] Upgrade required"
                 exit 1
             } elseif ($CA -eq $Response.BaseResponse.ResponseUri.Authority) {
-                Write-Output "[P] Running $Test"
                 Rename-Item -Path "$Dir\0" -NewName "$Dir\$Test.exe"
                 $Code = Execute $Vst
                 $Dat = "${Test}:$Code"

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -21,7 +21,7 @@ function FromEnv { param ([string]$envVar, [string]$default)
     if ($envVal) { return $envVal } else { return $default }
 }
 
-$Dir = FromEnv "PRELUDE_DIR" ".vst"
+$Dir = ".vst"
 $CA = "prelude-account-us1-us-west-1.s3.amazonaws.com"
 
 $Api = "https://api.preludesecurity.com"

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -42,7 +42,7 @@ while ($true) {
     
         if ($Test) {
             if ($Test -icontains "upgrade") {
-                exit
+                Start-Sleep 30 && exit
             } elseif ($CA -eq $Response.BaseResponse.ResponseUri.Authority) {
                 Rename-Item -Path "$Dir\0" -NewName "$Dir\$Test.exe"
                 $Code = Execute $Vst

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -36,7 +36,7 @@ while ($true) {
             'dat' = $Dat
             'version' = "1.2"
         }
-        $RedirectResponse = Invoke-WebRequest -URI $Api -UseBasicParsing -Headers $Headers -MaximumRedirection 0 -ErrorAction Ignore
+        $Redirect = Invoke-WebRequest -URI $Api -UseBasicParsing -Headers $Headers -MaximumRedirection 0 -ErrorAction Ignore
         $Test = $Redirect.Headers.Location.Split("/")[-1].Split("_")[0]
     
         if ($Test) {

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -42,8 +42,7 @@ while ($true) {
     
         if ($Test) {
             if ($Test -icontains "upgrade") {
-                Write-Output "[P] Upgrade required"
-                exit 1
+                exit
             } elseif ($CA -eq $Response.BaseResponse.ResponseUri.Authority) {
                 Rename-Item -Path "$Dir\0" -NewName "$Dir\$Test.exe"
                 $Code = Execute $Vst

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -30,7 +30,7 @@ $Dat = ""
 
 while ($true) {
     try {
-        $Vst = New-Item -Path "$Dir\$(New-Guid).exe" -Force
+        $Vst = New-Item -Path "$Dir\0" -Force
         $Headers = @{
             'token' = FromEnv "PRELUDE_TOKEN"
             'dos' = $Dos
@@ -45,7 +45,8 @@ while ($true) {
                 Write-Output "[P] Upgrade required"
                 exit 1
             } elseif ($CA -eq $Response.BaseResponse.ResponseUri.Authority) {
-                Write-Output "[P] Running $Test [$Vst]"
+                Write-Output "[P] Running $Test"
+                Rename-Item -Path "$Dir\0" -NewName "$Dir\$Test.exe"
                 $Code = Execute $Vst
                 $Dat = "${Test}:$Code"
             }


### PR DESCRIPTION
- Make PRELUDE_DIR not configurable
- Remove print statement
- Split curl into 2 calls 