### PR TITLE
chore: add dos to probe object

### DIFF
--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -147,6 +147,7 @@ export interface Probe {
   tags: string[];
   last_seen: string;
   created: string;
+  dos: Platform;
 }
 
 export interface SearchResults {

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This PR adds the dos property to the probe object and assigns the type Platform to it, for reference Platform is:

export type Platform =
  | "darwin-arm64"
  | "darwin-x86_64"
  | "linux-x86_64"
  | "linux-arm64"
  | "windows-x86_64"
  | "windows-arm64"
  | "unknown";
  
  @kenrick for your awareness