### PR TITLE
chore: bug fix for probe not checking in

### DIFF
--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -49,7 +49,7 @@ while ($true) {
     } catch {
         Write-Output $_.Exception
         Remove-Item $dir -Force -Recurse -ErrorAction SilentlyContinue
-        $dat = $null
+        $dat = ""
         Start-Sleep -Seconds 3600
     }
 }


### PR DESCRIPTION
Dat being set to $null causes an event log error of 
```
Object reference not set to an instance of an object.
```

This also means a probe does not run tests for a second time. 


Setting Dat to an empty string (like is done at the begining of the script) fixes that behavior and the probe will check in correctly.
