### PR TITLE
chore: upstream ca name changed, update demos hosted on us2 to point at us2

### DIFF
--- a/.github/workflows/shell_probes-us1.yml
+++ b/.github/workflows/shell_probes-us1.yml
@@ -19,8 +19,7 @@ jobs:
         shell: bash
         run: |
           for i in shell/probe/nocturnal.sh shell/probe/raindrop.ps1 shell/probe/vision.sh; do
-            echo "Staging substitution for ${i}"
-            sed -i 's/prelude-account-us1-us-west-1.s3.amazonaws.com/${{ secrets.BUCKET_NAME }}.s3.amazonaws.com/g' ${i}
+            echo "Endpoint substitution for ${i}"
             sed -i 's!api.preludesecurity.com!api.us1.preludesecurity.com!g' ${i}
           done
 

--- a/.github/workflows/shell_probes-us2.yml
+++ b/.github/workflows/shell_probes-us2.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Env Conversion
         shell: bash
         run: |
-          for i in shell/probe/nocturnal.sh shell/probe/raindrop.ps1 shell/probe/vision.sh; do
-            echo "Staging substitution for ${i}"
-            sed -i 's/prelude-account-us1-us-west-1.s3.amazonaws.com/${{ secrets.BUCKET_NAME }}.s3.amazonaws.com/g' ${i}
+          for i in shell/probe/nocturnal.sh shell/probe/raindrop.ps1 shell/probe/vision.sh shell/demo/demo.sh shell/demo/demo.ps1; do
+            echo "Endpoint substitution for ${i}"
+            sed -i 's/prelude-account-us1-us-east-2.s3.amazonaws.com/${{ secrets.BUCKET_NAME }}.s3.amazonaws.com/g' ${i}
             sed -i 's!api.preludesecurity.com!api.us2.preludesecurity.com!g' ${i}
           done
 


### PR DESCRIPTION
We updated the CA in the upstream probes to be running able straight from the repo. Need to update the workflows to account for this, so us2 points at us2 when hosted on us2. 

While I was in there, realized we should point the demo scripts hosted on us2 at us2 instead of us1, so that's included in the commit. 
