### PR TITLE
fix: verify User URL & add resetPassword test

### DIFF
--- a/javascript/sdk/lib/controllers/iam.ts
+++ b/javascript/sdk/lib/controllers/iam.ts
@@ -111,7 +111,7 @@ export default class IAMController {
   ): Promise<VerifiedUser> {
     const searchParams = new URLSearchParams({ token: token.toString() });
     const response = await this.#client.request(
-      `/iam/user?$${searchParams.toString()}`,
+      `/iam/user?${searchParams.toString()}`,
       {
         method: "GET",
         ...options,

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "type": "module",
   "files": [
     "dist"

--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -92,6 +92,16 @@ describe("SDK Test", () => {
       expect(account).toHaveProperty("users");
       expect(account.users).to.have.lengthOf(1);
     });
+
+    it("passwordReset should return a status true", async () => {
+      const account = await service.iam.getAccount();
+      const result = await service.iam.resetPassword(
+        account.account_id,
+        testEmail
+      );
+      expect(result).toHaveProperty("status");
+      expect(result.status).toEqual(true);
+    });
   });
 
   describe("Build Controller", async () => {


### PR DESCRIPTION
This test will not pass until we adjust the response on the BE to be `{status: true}` instead of the currently `{Status:true}` which is not aligned to how other endpoints respond.