### PR TITLE
chore: revive advisories and tests view

### DIFF
--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -2,6 +2,7 @@ import Client from "../client";
 import {
   Activity,
   ActivityQuery,
+  AdvisoriesActivity,
   Advisory,
   AttachedTest,
   DayActivity,
@@ -14,9 +15,9 @@ import {
   ProbeActivity,
   RegisterEndpointParams,
   RequestOptions,
-  SocialActivity,
   StatusResponse,
   Test,
+  TestsActivity,
   UpdateEndpointParams,
   UpdatedEndpoint,
 } from "../types";
@@ -137,9 +138,13 @@ export default class DetectController {
     options?: RequestOptions
   ): Promise<MetricsActivity[]>;
   async describeActivity(
-    query: ActivityQuery & { view: "social" },
+    query: ActivityQuery & { view: "advisories" },
     options?: RequestOptions
-  ): Promise<SocialActivity>;
+  ): Promise<AdvisoriesActivity[]>;
+  async describeActivity(
+    query: ActivityQuery & { view: "tests" },
+    options?: RequestOptions
+  ): Promise<TestsActivity[]>;
   async describeActivity(
     query: ActivityQuery & {
       view:
@@ -148,7 +153,8 @@ export default class DetectController {
         | "insights"
         | "probes"
         | "metrics"
-        | "social";
+        | "advisories"
+        | "tests";
     },
     options: RequestOptions = {}
   ) {

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -243,10 +243,10 @@ export interface Activity {
   control: ControlCode | null;
 }
 
-export interface TestUsage {
-  count: number;
-  not_relevant: number;
-  failed: number;
+export interface TestsActivity {
+  id: string;
+  unprotected: number;
+  volume: number;
 }
 
 export interface Advisory {
@@ -254,6 +254,12 @@ export interface Advisory {
   name: string;
   source: string;
   published: string;
+}
+
+export interface AdvisoriesActivity {
+  id: string;
+  unprotected: number;
+  volume: number;
 }
 
 export interface SocialActivity {
@@ -271,6 +277,7 @@ export interface ActivityQuery {
   statuses?: string;
   tags?: string;
   control?: ControlCode;
+  impersonate?: string;
 }
 
 export interface DayActivity {

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This PR brings back the advisories and tests views and adds in the optional field of "impersonate" for the activity query