### PR TITLE
Increase endpoint timeout to 20 seconds

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -30,7 +30,7 @@ func Start(test fn, clean ...fn) {
 	}()
 
 	select {
-	case <-time.After(10 * time.Second):
+	case <-time.After(20 * time.Second):
 		os.Exit(102)
 	}
 }


### PR DESCRIPTION
Adding some wiggle room to compensate for Windows Defender. There are instances where Defender's quarantine process causes tests to hit timeout. Tested with 20 seconds on my end and can no longer recreate the issue. 