### PR TITLE
update activity types and remove tags

### DIFF
--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -168,6 +168,7 @@ export default class DetectController {
     if (query.result_id) searchParams.set("result_id", query.result_id);
     if (query.dos) searchParams.set("dos", query.dos);
     if (query.control) searchParams.set("control", query.control.toString());
+    if (query.impersonate) searchParams.set("impersonate", query.impersonate);
 
     const response = await this.#client.requestWithAuth(
       `/detect/activity?${searchParams.toString()}`,

--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -163,10 +163,9 @@ export default class DetectController {
     searchParams.set("start", query.start);
     searchParams.set("finish", query.finish);
     if (query.tests) searchParams.set("tests", query.tests);
-    if (query.tags) searchParams.set("tags", query.tags);
     if (query.endpoints) searchParams.set("endpoints", query.endpoints);
-    if (query.result_id) searchParams.set("result_id", query.result_id);
     if (query.dos) searchParams.set("dos", query.dos);
+    if (query.statuses) searchParams.set("statuses", query.statuses);
     if (query.control) searchParams.set("control", query.control.toString());
     if (query.impersonate) searchParams.set("impersonate", query.impersonate);
 

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -236,11 +236,9 @@ export interface Activity {
   date: string;
   endpoint_id: string;
   id: string;
-  observed: 0 | 1;
   status: ExitCode;
   test: string;
   dos: Platform;
-  tags: string[] | null;
   control: ControlCode;
 }
 
@@ -284,7 +282,6 @@ export interface DayActivity {
 
 export interface Insight {
   dos: string | null;
-  tag: string | null;
   test: string | null;
   volume: { error: number; protected: number; unprotected: number };
 }
@@ -293,8 +290,7 @@ export interface ProbeActivity {
   dos: Platform;
   endpoint_id: string;
   state: "PROTECTED" | "UNPROTECTED" | "ERROR";
-  tags: string[];
-  control: ControlCode | null;
+  control: ControlCode;
 }
 
 export interface MetricsActivity {

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -265,11 +265,9 @@ export interface ActivityQuery {
   start: string;
   finish: string;
   tests?: string;
-  result_id?: string;
   endpoints?: string;
   dos?: string;
   statuses?: string;
-  tags?: string;
   control?: ControlCode;
   impersonate?: string;
 }

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -144,11 +144,11 @@ export interface Probe {
   host: string;
   serial_num: string;
   edr_id: string | null;
-  control: ControlCode | null;
+  control: ControlCode;
   tags: string[];
   last_seen: string;
   created: string;
-  dos: Platform;
+  dos: Platform | null;
 }
 
 export const ExitCodes = {

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "type": "module",
   "files": [
     "dist"

--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -187,7 +187,7 @@ describe("SDK Test", () => {
     beforeAll(async () => {
       const credentials = await createAccount();
       service.setCredentials(credentials);
-      await service.iam.updateAccount(Modes.MANUAL, company)
+      await service.iam.updateAccount(Modes.MANUAL, company);
     });
 
     afterAll(async () => {


### PR DESCRIPTION
This PR does the following:

- Remove tags from "insights", "probes", and "logs" views
- Add impersonate to the query
- Remove deprecated "observed" property from "logs"
- Remove null from control for endpoints and "probes" view responses
- Add null option for dos on endpoints response