### PR TITLE
add power and default views (JS SDK 1.4.14)

### DIFF
--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -5,6 +5,8 @@ import {
   AdvisoriesActivity,
   Advisory,
   AttachedTest,
+  ControlActivity,
+  DOSActivity,
   DayActivity,
   DisableTest,
   EnableTest,
@@ -146,6 +148,14 @@ export default class DetectController {
     options?: RequestOptions
   ): Promise<TestsActivity[]>;
   async describeActivity(
+    query: ActivityQuery & { view: "dos" },
+    options?: RequestOptions
+  ): Promise<DOSActivity[]>;
+  async describeActivity(
+    query: ActivityQuery & { view: "control" },
+    options?: RequestOptions
+  ): Promise<ControlActivity[]>;
+  async describeActivity(
     query: ActivityQuery & {
       view:
         | "days"
@@ -154,7 +164,9 @@ export default class DetectController {
         | "probes"
         | "metrics"
         | "advisories"
-        | "tests";
+        | "tests"
+        | "dos"
+        | "control";
     },
     options: RequestOptions = {}
   ) {

--- a/javascript/sdk/lib/controllers/detect.ts
+++ b/javascript/sdk/lib/controllers/detect.ts
@@ -5,14 +5,13 @@ import {
   AdvisoriesActivity,
   Advisory,
   AttachedTest,
-  ControlActivity,
-  DOSActivity,
   DayActivity,
   DisableTest,
   EnableTest,
   EnabledTest,
   Insight,
   MetricsActivity,
+  PowerActivity,
   Probe,
   ProbeActivity,
   RegisterEndpointParams,
@@ -148,13 +147,13 @@ export default class DetectController {
     options?: RequestOptions
   ): Promise<TestsActivity[]>;
   async describeActivity(
-    query: ActivityQuery & { view: "dos" },
+    query: ActivityQuery & { view: "power" },
     options?: RequestOptions
-  ): Promise<DOSActivity[]>;
+  ): Promise<PowerActivity[]>;
   async describeActivity(
-    query: ActivityQuery & { view: "control" },
+    query: ActivityQuery & { view: "default" },
     options?: RequestOptions
-  ): Promise<ControlActivity[]>;
+  ): Promise<number>;
   async describeActivity(
     query: ActivityQuery & {
       view:
@@ -165,8 +164,8 @@ export default class DetectController {
         | "metrics"
         | "advisories"
         | "tests"
-        | "dos"
-        | "control";
+        | "power"
+        | "default";
     },
     options: RequestOptions = {}
   ) {

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -248,7 +248,7 @@ export interface Activity {
 
 export interface TestsActivity {
   id: string;
-  unprotected: number;
+  protected: number;
   volume: number;
 }
 
@@ -261,7 +261,7 @@ export interface Advisory {
 
 export interface AdvisoriesActivity {
   id: string;
-  unprotected: number;
+  protected: number;
   volume: number;
 }
 
@@ -311,7 +311,7 @@ export interface Recommendation {
 }
 
 export interface PowerActivity {
-  unprotected: number;
+  protected: number;
   dos?: Platform;
   control?: ControlCode;
   policy?: string;

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -304,15 +304,20 @@ export interface MetricsActivity {
   unique_tests: number;
 }
 
-export type DOSActivity = Record<
-  NonArchPlatform,
-  { unprotected: number; significant: number }
->;
+export interface Recommendation {
+  key: string;
+  value: string;
+  improvement: number;
+}
 
-export type ControlActivity = Record<
-  `${ControlCode}`,
-  { unprotected: number; significant: number }
->;
+export interface PowerActivity {
+  unprotected: number;
+  dos?: Platform;
+  control?: ControlCode;
+  policy?: string;
+  version?: string;
+  recommendation?: Recommendation;
+}
 
 export interface RegisterEndpointParams {
   host: string;

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -249,7 +249,6 @@ export interface Activity {
 export interface TestsActivity {
   id: string;
   protected: number;
-  volume: number;
 }
 
 export interface Advisory {
@@ -262,7 +261,6 @@ export interface Advisory {
 export interface AdvisoriesActivity {
   id: string;
   protected: number;
-  volume: number;
 }
 
 export interface ActivityQuery {

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -111,7 +111,7 @@ export const Permissions = {
   EXECUTIVE: 1,
   BUILD: 2,
   SERVICE: 3,
-  AUTO: 4
+  AUTO: 4,
 } as const;
 
 export type Permission = (typeof Permissions)[keyof typeof Permissions];
@@ -149,6 +149,8 @@ export interface Probe {
   last_seen: string;
   created: string;
   dos: Platform | null;
+  version?: string;
+  policy?: string;
 }
 
 export const ExitCodes = {
@@ -223,6 +225,8 @@ export const ControlCodes = {
 export type ControlCodeName = keyof typeof ControlCodes;
 export type ControlCode = (typeof ControlCodes)[ControlCodeName];
 
+export type NonArchPlatform = "darwin" | "linux" | "windows";
+
 export type Platform =
   | "darwin-arm64"
   | "darwin-x86_64"
@@ -289,6 +293,7 @@ export interface ProbeActivity {
   endpoint_id: string;
   state: "PROTECTED" | "UNPROTECTED" | "ERROR";
   control: ControlCode;
+  status?: number;
 }
 
 export interface MetricsActivity {
@@ -298,6 +303,16 @@ export interface MetricsActivity {
   company: string;
   unique_tests: number;
 }
+
+export type DOSActivity = Record<
+  NonArchPlatform,
+  { unprotected: number; significant: number }
+>;
+
+export type ControlActivity = Record<
+  `${ControlCode}`,
+  { unprotected: number; significant: number }
+>;
 
 export interface RegisterEndpointParams {
   host: string;

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theprelude/sdk",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "type": "module",
   "files": [
     "dist"

--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -245,7 +245,6 @@ describe("SDK Test", () => {
 
       const result = (await service.iam.getAccount()).queue;
 
-      expect(result).toHaveLength(1);
       expect(result).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -312,7 +311,11 @@ describe("SDK Test", () => {
             finish,
             view: "logs",
           });
-          expect(result).toHaveLength(1);
+          expect(result).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ test: activeTest }),
+            ])
+          );
         },
         { retry: 5 }
       );
@@ -337,7 +340,14 @@ describe("SDK Test", () => {
         tags: tags,
       });
       const result = (await service.iam.getAccount()).queue;
-      expect(result).toHaveLength(0);
+      expect(result).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            test: activeTest,
+            run_code: RunCodes.DAILY,
+          }),
+        ])
+      );
     });
 
     it("deleteEndpoint should remove the endpoint from the list", async function () {

--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -233,7 +233,7 @@ describe("SDK Test", () => {
         expect(download).toContain(testId);
         expect(download).toContain(testName);
       },
-      { timeout: 10_000 }
+      { timeout: 15_000 }
     );
 
     it("enableTest should add a new test to the queue", async function () {

--- a/python/sdk/tests/test_detect_controller.py
+++ b/python/sdk/tests/test_detect_controller.py
@@ -85,7 +85,7 @@ class TestDetectController:
                 finish=datetime.utcnow() + timedelta(days=1)
             )
             describe_activity = unwrap(self.detect.describe_activity)(self.detect, filters=filters | {'endpoint_id': pytest.endpoint_id})
-            assert len(describe_activity) == 1
+            assert len([test for test in describe_activity if test['test'] == pytest.test_id]) == 1
         finally:
             os.remove(pytest.probe)
     


### PR DESCRIPTION
Adds new power and default views. Adds powerActivity typing for the power view response. In that response, we say that policy, version, dos, and control are all optional properties and may not be returned from the BE

Adjusts for better checks on tests