### PR TITLE
Feature: Add constants for results

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -35,6 +35,30 @@ func Start(test fn, clean ...fn) {
 	}
 }
 
+const (
+	// Errors
+	UnexpectedTestError      int = 1
+	TimeoutExceeded          int = 102
+	CleanupFailed            int = 103
+	OutOfMemory              int = 137
+	UnexpectedExecutionError int = 256
+
+	// Not Relevant
+	NotRelevant int = 104
+
+	// Protected
+	TestCompletedNormally       int = 100
+	FileQuarantinedOnExtraction int = 105
+	NetworkConnectionBlocked    int = 106
+	HostNotVulnerabile          int = 107
+	ExecutionPrevented          int = 126
+	FileQuarantinedOnExecution  int = 127
+
+	// Unprotected
+	Unprotected            int = 101
+	TestIncorrectlyBlocked int = 110
+)
+
 func Stop(code int) {
 	cleanup()
 	Say(fmt.Sprintf("Completed with code: %d", code))


### PR DESCRIPTION
This PR adds a collections of constants which reflect the error codes defined in the [Detect docs](https://docs.preludesecurity.com/docs/understanding-results) and use descriptive names. Merging this would allow us to create tests like this:

```go
func test() {
    Endpoint.Say("Extracting file for quarantine test")
    Endpoint.Say("Pausing for 3 seconds to gauge defensive reaction") 
    if Endpoint.Quarantined("SharpWMI.exe", malicious) {
        Endpoint.Say("Malicious file was caught!")
        Endpoint.Stop(Endpoint.FileQuarantinedOnExtraction)
        return
    }

    Endpoint.Say("Malicious file was not caught")

    Endpoint.Say("Executing SharpWMI")
    randomIndex := rand.Intn(len(commands))
    command := commands[randomIndex]

    _, err := Endpoint.Shell(command)
    if err != nil {
        Endpoint.Say("Execution was prevented")
        Endpoint.Stop(Endpoint.ExecutionPrevented)
    }

    Endpoint.Say("SharpWMI was not blocked")
    Endpoint.Stop(Endpoint.Unprotected}
``` 