### PR TITLE
Replace println() with Endpoint.Say() in Go test template

### DIFF
--- a/python/cli/prelude_cli/templates/template.go
+++ b/python/cli/prelude_cli/templates/template.go
@@ -15,7 +15,7 @@ func test() {
 }
 
 func clean() {
-	println("[+] Cleaning up")
+	Endpoint.Say("Cleaning up")
 }
 
 func main() {


### PR DESCRIPTION
This is a simple upgrade to the template used when creating a new test that will make use of the new logging function.