### PR TITLE
Remove unnessary imports from Endpoint.

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -3,14 +3,11 @@ package Endpoint
 import (
 	"fmt"
 	"io/fs"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 


### PR DESCRIPTION
Missed these when I removed the PortScan struct.