### PR TITLE
det-772 [a]: pass enum strings to API

### DIFF
--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -98,7 +98,7 @@ def download(controller, test):
 def enable_test(controller, test, run_code, tags):
     """ Add test to your queue """
     with Spinner(description='Enabling test'):
-        data = controller.enable_test(ident=test, run_code=run_code.upper(), tags=tags)
+        data = controller.enable_test(ident=test, run_code=RunCode[run_code], tags=tags)
     print_json(data=data)
 
 

--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -98,7 +98,7 @@ def download(controller, test):
 def enable_test(controller, test, run_code, tags):
     """ Add test to your queue """
     with Spinner(description='Enabling test'):
-        data = controller.enable_test(ident=test, run_code=RunCode[run_code.upper()].value, tags=tags)
+        data = controller.enable_test(ident=test, run_code=run_code.upper(), tags=tags)
     print_json(data=data)
 
 

--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -92,7 +92,7 @@ def download(controller, test):
 @click.option('-r', '--run_code',
               help='provide a run_code',
               default=RunCode.DAILY.name, show_default=True,
-              type=click.Choice([r.name for r in RunCode], case_sensitive=False))
+              type=click.Choice([r.name for r in RunCode if r != RunCode.INVALID], case_sensitive=False))
 @click.pass_obj
 @handle_api_error
 def enable_test(controller, test, run_code, tags):

--- a/python/cli/prelude_cli/views/iam.py
+++ b/python/cli/prelude_cli/views/iam.py
@@ -45,7 +45,7 @@ def update_account(controller, mode, company):
     """ Update an account """
     with Spinner(description='Updating account information'):
         data = controller.update_account(
-            mode=Mode[mode.upper()].value if mode else None,
+            mode=mode,
             company=company
         )
     print_json(data=data)
@@ -75,7 +75,7 @@ def create_user(controller, days, permission, name, email):
     with Spinner(description='Creating new user'):
         data = controller.create_user(
             email=email,
-            permission=Permission[permission.upper()].value,
+            permission=permission.upper(),
             name=name,
             expires=expires
         )

--- a/python/cli/prelude_cli/views/iam.py
+++ b/python/cli/prelude_cli/views/iam.py
@@ -43,9 +43,11 @@ def register_account(controller):
 @handle_api_error
 def update_account(controller, mode, company):
     """ Update an account """
+    print(mode)
+    print(Mode[mode])
     with Spinner(description='Updating account information'):
         data = controller.update_account(
-            mode=mode.upper(),
+            mode=Mode[mode],
             company=company
         )
     print_json(data=data)
@@ -75,7 +77,7 @@ def create_user(controller, days, permission, name, email):
     with Spinner(description='Creating new user'):
         data = controller.create_user(
             email=email,
-            permission=permission.upper(),
+            permission=Permission[permission],
             name=name,
             expires=expires
         )

--- a/python/cli/prelude_cli/views/iam.py
+++ b/python/cli/prelude_cli/views/iam.py
@@ -45,7 +45,7 @@ def update_account(controller, mode, company):
     """ Update an account """
     with Spinner(description='Updating account information'):
         data = controller.update_account(
-            mode=mode,
+            mode=mode.upper(),
             company=company
         )
     print_json(data=data)

--- a/python/cli/prelude_cli/views/iam.py
+++ b/python/cli/prelude_cli/views/iam.py
@@ -35,16 +35,11 @@ def register_account(controller):
               help='provide a mode',
               default=None, show_default=False,
               type=click.Choice([m.name for m in Mode], case_sensitive=False))
-@click.option('-c', '--company',
-              help='provide your associated company',
-              default=None, show_default=False,
-              type=str)
+@click.option('-c', '--company', help='provide your associated company', default=None, show_default=False, type=str)
 @click.pass_obj
 @handle_api_error
 def update_account(controller, mode, company):
     """ Update an account """
-    print(mode)
-    print(Mode[mode])
     with Spinner(description='Updating account information'):
         data = controller.update_account(
             mode=Mode[mode],

--- a/python/cli/prelude_cli/views/iam.py
+++ b/python/cli/prelude_cli/views/iam.py
@@ -42,7 +42,7 @@ def update_account(controller, mode, company):
     """ Update an account """
     with Spinner(description='Updating account information'):
         data = controller.update_account(
-            mode=Mode[mode],
+            mode=Mode[mode] if mode else None,
             company=company
         )
     print_json(data=data)

--- a/python/cli/prelude_cli/views/partner.py
+++ b/python/cli/prelude_cli/views/partner.py
@@ -25,7 +25,7 @@ def partner(ctx):
 def attach_partner(controller, partner, api, user, secret):
     """ Attach an EDR to Detect """
     with Spinner(description='Attaching partner'):
-        data = controller.attach(partner=partner.upper(), api=api, user=user, secret=secret)
+        data = controller.attach(partner=Control[partner], api=api, user=user, secret=secret)
     print_json(data=data)
 
 
@@ -38,7 +38,7 @@ def attach_partner(controller, partner, api, user, secret):
 def detach_partner(controller, partner):
     """ Detach an existing partner from your account """
     with Spinner(description='Detaching partner'):
-        data = controller.detach(partner=partner.upper())
+        data = controller.detach(partner=Control[partner])
     print_json(data=data)
 
 
@@ -51,7 +51,7 @@ def detach_partner(controller, partner):
 def partner_block(controller, partner, test_id):
     """ Report to a partner to block a test """
     with Spinner(description='Reporting test to partner'):
-        data = controller.block(partner=partner.upper(), test_id=test_id)
+        data = controller.block(partner=Control[partner], test_id=test_id)
     print_json(data=data)
 
 
@@ -66,7 +66,7 @@ def partner_block(controller, partner, test_id):
 def partner_endpoints(controller, partner, platform, hostname, offset):
     """ Get a list of endpoints from a partner """
     with Spinner(description='Fetching endpoints from partner'):
-        data = controller.endpoints(partner=partner.upper(), platform=platform, hostname=hostname, offset=offset)
+        data = controller.endpoints(partner=Control[partner], platform=platform, hostname=hostname, offset=offset)
     print_json(data=data)
 
 
@@ -79,7 +79,7 @@ def partner_endpoints(controller, partner, platform, hostname, offset):
 def partner_deploy(controller, partner, host_ids):
     """ Deploy probes to hosts associated to a partner """
     with Spinner(description='Deploying probes to hosts'):
-        data = controller.deploy(partner=partner.upper(), host_ids=host_ids)
+        data = controller.deploy(partner=Control[partner], host_ids=host_ids)
     print_json(data=data)
 
 
@@ -90,6 +90,6 @@ def partner_deploy(controller, partner, host_ids):
 def generate_webhook(controller, partner):
     """ Generate webhook credentials for an EDR system to enable the forwarding of alerts to the Prelude API, facilitating automatic alert suppression """
     with Spinner(description='Generating webhook credentials'):
-        data = controller.generate_webhook(partner=partner.upper())
+        data = controller.generate_webhook(partner=Control[partner])
     print_json(data=data)
     print("\nVisit https://docs.preludesecurity.com/docs/alert-management for details on configuring your EDR to forward alerts.\n")

--- a/python/cli/prelude_cli/views/partner.py
+++ b/python/cli/prelude_cli/views/partner.py
@@ -16,7 +16,7 @@ def partner(ctx):
 
 @partner.command('attach')
 @click.argument('partner',
-              type=click.Choice([c.name for c in Control if c != Control.INVALID], case_sensitive=False))
+                type=click.Choice([c.name for c in Control if c != Control.INVALID], case_sensitive=False))
 @click.option('--api', required=True, help='API endpoint of the partner')
 @click.option('--user', default='', help='user identifier')
 @click.option('--secret', default='', help='secret for OAUTH use cases')
@@ -25,39 +25,39 @@ def partner(ctx):
 def attach_partner(controller, partner, api, user, secret):
     """ Attach an EDR to Detect """
     with Spinner(description='Attaching partner'):
-        data = controller.attach(partner_code=partner.upper(), api=api, user=user, secret=secret)
+        data = controller.attach(partner=partner.upper(), api=api, user=user, secret=secret)
     print_json(data=data)
 
 
 @partner.command('detach')
 @click.confirmation_option(prompt='Are you sure?')
 @click.argument('partner',
-              type=click.Choice([c.name for c in Control if c != Control.INVALID], case_sensitive=False))
+                type=click.Choice([c.name for c in Control if c != Control.INVALID], case_sensitive=False))
 @click.pass_obj
 @handle_api_error
 def detach_partner(controller, partner):
     """ Detach an existing partner from your account """
     with Spinner(description='Detaching partner'):
-        data = controller.detach(partner_code=partner.upper())
+        data = controller.detach(partner=partner.upper())
     print_json(data=data)
 
 
 @partner.command('block')
 @click.argument('partner',
-              type=click.Choice([c.name for c in Control if c != Control.INVALID], case_sensitive=False))
+                type=click.Choice([c.name for c in Control if c != Control.INVALID], case_sensitive=False))
 @click.option('-t', '--test_id', required=True, help='a test to block')
 @click.pass_obj
 @handle_api_error
 def partner_block(controller, partner, test_id):
     """ Report to a partner to block a test """
     with Spinner(description='Reporting test to partner'):
-        data = controller.block(partner_code=partner.upper(), test_id=test_id)
+        data = controller.block(partner=partner.upper(), test_id=test_id)
     print_json(data=data)
 
 
 @partner.command('endpoints')
 @click.argument('partner',
-              type=click.Choice([c.name for c in Control if c != Control.INVALID], case_sensitive=False))
+                type=click.Choice([c.name for c in Control if c != Control.INVALID], case_sensitive=False))
 @click.option('--platform', required=True, help='platform name (e.g. "windows")', type=click.Choice(['windows', 'linux', 'darwin'], case_sensitive=False))
 @click.option('--hostname', default='', help='hostname pattern (e.g. "mycompany-c24oi444")')
 @click.option('--offset', default=0, help='API pagination offset', type=int)
@@ -66,7 +66,7 @@ def partner_block(controller, partner, test_id):
 def partner_endpoints(controller, partner, platform, hostname, offset):
     """ Get a list of endpoints from a partner """
     with Spinner(description='Fetching endpoints from partner'):
-        data = controller.endpoints(partner_code=partner.upper(), platform=platform, hostname=hostname, offset=offset)
+        data = controller.endpoints(partner=partner.upper(), platform=platform, hostname=hostname, offset=offset)
     print_json(data=data)
 
 
@@ -79,7 +79,7 @@ def partner_endpoints(controller, partner, platform, hostname, offset):
 def partner_deploy(controller, partner, host_ids):
     """ Deploy probes to hosts associated to a partner """
     with Spinner(description='Deploying probes to hosts'):
-        data = controller.deploy(partner_code=partner.upper(), host_ids=host_ids)
+        data = controller.deploy(partner=partner.upper(), host_ids=host_ids)
     print_json(data=data)
 
 
@@ -90,6 +90,6 @@ def partner_deploy(controller, partner, host_ids):
 def generate_webhook(controller, partner):
     """ Generate webhook credentials for an EDR system to enable the forwarding of alerts to the Prelude API, facilitating automatic alert suppression """
     with Spinner(description='Generating webhook credentials'):
-        data = controller.generate_webhook(partner_code=partner.upper())
+        data = controller.generate_webhook(partner=partner.upper())
     print_json(data=data)
     print("\nVisit https://docs.preludesecurity.com/docs/alert-management for details on configuring your EDR to forward alerts.\n")

--- a/python/cli/prelude_cli/views/partner.py
+++ b/python/cli/prelude_cli/views/partner.py
@@ -25,7 +25,7 @@ def partner(ctx):
 def attach_partner(controller, partner, api, user, secret):
     """ Attach an EDR to Detect """
     with Spinner(description='Attaching partner'):
-        data = controller.attach(partner_code=Control[partner.upper()].value, api=api, user=user, secret=secret)
+        data = controller.attach(partner_code=partner.upper(), api=api, user=user, secret=secret)
     print_json(data=data)
 
 
@@ -38,7 +38,7 @@ def attach_partner(controller, partner, api, user, secret):
 def detach_partner(controller, partner):
     """ Detach an existing partner from your account """
     with Spinner(description='Detaching partner'):
-        data = controller.detach(partner_code=Control[partner.upper()].value)
+        data = controller.detach(partner_code=partner.upper())
     print_json(data=data)
 
 
@@ -51,7 +51,7 @@ def detach_partner(controller, partner):
 def partner_block(controller, partner, test_id):
     """ Report to a partner to block a test """
     with Spinner(description='Reporting test to partner'):
-        data = controller.block(partner_code=Control[partner.upper()].value, test_id=test_id)
+        data = controller.block(partner_code=partner.upper(), test_id=test_id)
     print_json(data=data)
 
 
@@ -66,7 +66,7 @@ def partner_block(controller, partner, test_id):
 def partner_endpoints(controller, partner, platform, hostname, offset):
     """ Get a list of endpoints from a partner """
     with Spinner(description='Fetching endpoints from partner'):
-        data = controller.endpoints(partner_code=Control[partner.upper()].value, platform=platform, hostname=hostname, offset=offset)
+        data = controller.endpoints(partner_code=partner.upper(), platform=platform, hostname=hostname, offset=offset)
     print_json(data=data)
 
 
@@ -79,7 +79,7 @@ def partner_endpoints(controller, partner, platform, hostname, offset):
 def partner_deploy(controller, partner, host_ids):
     """ Deploy probes to hosts associated to a partner """
     with Spinner(description='Deploying probes to hosts'):
-        data = controller.deploy(partner_code=Control[partner.upper()].value, host_ids=host_ids)
+        data = controller.deploy(partner_code=partner.upper(), host_ids=host_ids)
     print_json(data=data)
 
 
@@ -90,6 +90,6 @@ def partner_deploy(controller, partner, host_ids):
 def generate_webhook(controller, partner):
     """ Generate webhook credentials for an EDR system to enable the forwarding of alerts to the Prelude API, facilitating automatic alert suppression """
     with Spinner(description='Generating webhook credentials'):
-        data = controller.generate_webhook(partner_code=Control[partner.upper()].value)
+        data = controller.generate_webhook(partner_code=partner.upper())
     print_json(data=data)
     print("\nVisit https://docs.preludesecurity.com/docs/alert-management for details on configuring your EDR to forward alerts.\n")

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -1,5 +1,6 @@
 import requests
 
+from prelude_sdk.models.codes import RunCode
 from prelude_sdk.models.account import verify_credentials
 
 
@@ -135,12 +136,12 @@ class DetectController:
         raise Exception(res.text)
 
     @verify_credentials
-    def enable_test(self, ident: str, run_code: str, tags: str):
+    def enable_test(self, ident: str, run_code: RunCode, tags: str):
         """ Enable a test so endpoints will start running it """
         res = requests.post(
             url=f'{self.account.hq}/detect/queue/{ident}',
             headers=self.account.headers,
-            json=dict(code=run_code, tags=tags),
+            json=dict(code=run_code.name, tags=tags),
             timeout=10
         )
         if res.status_code == 200:

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -135,7 +135,7 @@ class DetectController:
         raise Exception(res.text)
 
     @verify_credentials
-    def enable_test(self, ident: str, run_code: int, tags: str):
+    def enable_test(self, ident: str, run_code: str, tags: str):
         """ Enable a test so endpoints will start running it """
         res = requests.post(
             url=f'{self.account.hq}/detect/queue/{ident}',

--- a/python/sdk/prelude_sdk/controllers/iam_controller.py
+++ b/python/sdk/prelude_sdk/controllers/iam_controller.py
@@ -52,7 +52,6 @@ class IAMController:
         body = dict()
         if mode is not None:
             body['mode'] = mode.name
-            print(mode.name)
         if company is not None:
             body['company'] = company
 

--- a/python/sdk/prelude_sdk/controllers/iam_controller.py
+++ b/python/sdk/prelude_sdk/controllers/iam_controller.py
@@ -47,7 +47,7 @@ class IAMController:
         raise Exception(res.text)
 
     @verify_credentials
-    def update_account(self, mode: int = None, company: str = None):
+    def update_account(self, mode: str = None, company: str = None):
         """ Update properties on an account """
         body = dict()
         if mode is not None:
@@ -78,7 +78,7 @@ class IAMController:
         raise Exception(res.text)
 
     @verify_credentials
-    def create_user(self, permission: int, email: str, expires: datetime = None, name: str = None):
+    def create_user(self, permission: str, email: str, expires: datetime = None, name: str = None):
         """ Create a new user inside an account """
         body = dict(permission=permission, handle=email)
         if name:

--- a/python/sdk/prelude_sdk/controllers/iam_controller.py
+++ b/python/sdk/prelude_sdk/controllers/iam_controller.py
@@ -1,7 +1,7 @@
 import requests
 import datetime
 
-from prelude_sdk.models.codes import AuditEvent
+from prelude_sdk.models.codes import AuditEvent, Mode, Permission
 from prelude_sdk.models.account import verify_credentials
 
 
@@ -47,11 +47,12 @@ class IAMController:
         raise Exception(res.text)
 
     @verify_credentials
-    def update_account(self, mode: str = None, company: str = None):
+    def update_account(self, mode: Mode = None, company: str = None):
         """ Update properties on an account """
         body = dict()
         if mode is not None:
-            body['mode'] = mode
+            body['mode'] = mode.name
+            print(mode.name)
         if company is not None:
             body['company'] = company
 
@@ -78,9 +79,9 @@ class IAMController:
         raise Exception(res.text)
 
     @verify_credentials
-    def create_user(self, permission: str, email: str, expires: datetime = None, name: str = None):
+    def create_user(self, permission: Permission, email: str, expires: datetime = None, name: str = None):
         """ Create a new user inside an account """
-        body = dict(permission=permission, handle=email)
+        body = dict(permission=permission.name, handle=email)
         if name:
             body['name'] = name
         if expires:

--- a/python/sdk/prelude_sdk/controllers/partner_controller.py
+++ b/python/sdk/prelude_sdk/controllers/partner_controller.py
@@ -1,5 +1,6 @@
 import requests
 
+from prelude_sdk.models.codes import Control
 from prelude_sdk.models.account import verify_credentials
 
 
@@ -9,11 +10,11 @@ class PartnerController:
         self.account = account
 
     @verify_credentials
-    def attach(self, partner: str, api: str, user: str, secret: str):
+    def attach(self, partner: Control, api: str, user: str, secret: str):
         """ Attach a partner to your account """
         params = dict(api=api, user=user, secret=secret)
         res = requests.post(
-            f'{self.account.hq}/partner/{partner}',
+            f'{self.account.hq}/partner/{partner.name}',
             headers=self.account.headers,
             json=params,
             timeout=10
@@ -23,10 +24,10 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def detach(self, partner: str):
+    def detach(self, partner: Control):
         """ Detach a partner from your Detect account """
         res = requests.delete(
-            f'{self.account.hq}/partner/{partner}',
+            f'{self.account.hq}/partner/{partner.name}',
             headers=self.account.headers,
             timeout=10
         )
@@ -35,11 +36,11 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def block(self, partner: str, test_id: str):
+    def block(self, partner: Control, test_id: str):
         """ Report to a partner to block a test """
         params = dict(test_id=test_id)
         res = requests.post(
-            f'{self.account.hq}/partner/block/{partner}',
+            f'{self.account.hq}/partner/block/{partner.name}',
             headers=self.account.headers,
             json=params,
             timeout=30
@@ -49,11 +50,11 @@ class PartnerController:
         raise Exception(res.text)
         
     @verify_credentials
-    def endpoints(self, partner: str, platform: str, hostname: str = '', offset: int = 0, count: int = 100):
+    def endpoints(self, partner: Control, platform: str, hostname: str = '', offset: int = 0, count: int = 100):
         """ Get a list of endpoints from a partner """
         params = dict(platform=platform, hostname=hostname, offset=offset, count=count)
         res = requests.get(
-            f'{self.account.hq}/partner/endpoints/{partner}',
+            f'{self.account.hq}/partner/endpoints/{partner.name}',
             headers=self.account.headers,
             params=params,
             timeout=30
@@ -63,10 +64,10 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def generate_webhook(self, partner: str):
+    def generate_webhook(self, partner: Control):
         """ Generate webhook credentials for an EDR system to enable the forwarding of alerts to the Prelude API, facilitating automatic alert suppression """
         res = requests.get(
-            f'{self.account.hq}/partner/suppress/{partner}',
+            f'{self.account.hq}/partner/suppress/{partner.name}',
             headers=self.account.headers,
             timeout=30
         )
@@ -75,11 +76,11 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def deploy(self, partner: str, host_ids: list):
+    def deploy(self, partner: Control, host_ids: list):
         """ Deploy probes on all specified partner endpoints """
         params = dict(host_ids=host_ids)
         res = requests.post(
-            f'{self.account.hq}/partner/deploy/{partner}',
+            f'{self.account.hq}/partner/deploy/{partner.name}',
             headers=self.account.headers,
             json=params,
             timeout=30

--- a/python/sdk/prelude_sdk/controllers/partner_controller.py
+++ b/python/sdk/prelude_sdk/controllers/partner_controller.py
@@ -9,11 +9,11 @@ class PartnerController:
         self.account = account
 
     @verify_credentials
-    def attach(self, partner_code: int, api: str, user: str, secret: str):
+    def attach(self, partner: str, api: str, user: str, secret: str):
         """ Attach a partner to your account """
         params = dict(api=api, user=user, secret=secret)
         res = requests.post(
-            f'{self.account.hq}/partner/{partner_code}',
+            f'{self.account.hq}/partner/{partner}',
             headers=self.account.headers,
             json=params,
             timeout=10
@@ -23,10 +23,10 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def detach(self, partner_code: int):
+    def detach(self, partner: str):
         """ Detach a partner from your Detect account """
         res = requests.delete(
-            f'{self.account.hq}/partner/{partner_code}',
+            f'{self.account.hq}/partner/{partner}',
             headers=self.account.headers,
             timeout=10
         )
@@ -35,11 +35,11 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def block(self, partner_code: int, test_id: str):
+    def block(self, partner: str, test_id: str):
         """ Report to a partner to block a test """
         params = dict(test_id=test_id)
         res = requests.post(
-            f'{self.account.hq}/partner/block/{partner_code}',
+            f'{self.account.hq}/partner/block/{partner}',
             headers=self.account.headers,
             json=params,
             timeout=30
@@ -49,11 +49,11 @@ class PartnerController:
         raise Exception(res.text)
         
     @verify_credentials
-    def endpoints(self, partner_code: int, platform: str, hostname: str = '', offset: int = 0, count: int = 100):
+    def endpoints(self, partner: str, platform: str, hostname: str = '', offset: int = 0, count: int = 100):
         """ Get a list of endpoints from a partner """
         params = dict(platform=platform, hostname=hostname, offset=offset, count=count)
         res = requests.get(
-            f'{self.account.hq}/partner/endpoints/{partner_code}',
+            f'{self.account.hq}/partner/endpoints/{partner}',
             headers=self.account.headers,
             params=params,
             timeout=30
@@ -63,10 +63,10 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def generate_webhook(self, partner_code: int):
+    def generate_webhook(self, partner: str):
         """ Generate webhook credentials for an EDR system to enable the forwarding of alerts to the Prelude API, facilitating automatic alert suppression """
         res = requests.get(
-            f'{self.account.hq}/partner/suppress/{partner_code}',
+            f'{self.account.hq}/partner/suppress/{partner}',
             headers=self.account.headers,
             timeout=30
         )
@@ -75,11 +75,11 @@ class PartnerController:
         raise Exception(res.text)
 
     @verify_credentials
-    def deploy(self, partner_code: int, host_ids: list):
+    def deploy(self, partner: str, host_ids: list):
         """ Deploy probes on all specified partner endpoints """
         params = dict(host_ids=host_ids)
         res = requests.post(
-            f'{self.account.hq}/partner/deploy/{partner_code}',
+            f'{self.account.hq}/partner/deploy/{partner}',
             headers=self.account.headers,
             json=params,
             timeout=30

--- a/python/sdk/prelude_sdk/models/codes.py
+++ b/python/sdk/prelude_sdk/models/codes.py
@@ -6,7 +6,7 @@ class MissingItem(EnumMeta):
         try:
             return super().__getitem__(name.upper())
         except KeyError:
-            return cls(None)
+            return cls(name)
 
 
 class RunCode(Enum, metaclass=MissingItem):

--- a/python/sdk/prelude_sdk/models/codes.py
+++ b/python/sdk/prelude_sdk/models/codes.py
@@ -168,14 +168,14 @@ class AuditEvent(Enum, metaclass=MissingItem):
     DELETE_USER = 6
     DETACH_PARTNER = 7
     DISABLE_TEST = 8
-    DOWNLOAD_ATTACHMENT = 9
+    DOWNLOAD_TEST_ATTACHMENT = 9
     ENABLE_TEST = 10
-    PARTNER_BLOCK = 11
+    SUPPRESS_PARTNER_ALERTS = 11
     REGISTER_ENDPOINT = 12
     UPDATE_ACCOUNT = 13
     UPDATE_ENDPOINT = 14
     UPDATE_TEST = 15
-    UPLOAD_ATTACHMENT = 16
+    UPLOAD_TEST_ATTACHMENT = 16
 
     @classmethod
     def _missing_(cls, value):

--- a/python/sdk/prelude_sdk/models/codes.py
+++ b/python/sdk/prelude_sdk/models/codes.py
@@ -1,7 +1,15 @@
-from enum import Enum
+from enum import Enum, EnumMeta
 
 
-class RunCode(Enum):
+class MissingItem(EnumMeta):
+    def __getitem__(cls, name):
+        try:
+            return super().__getitem__(name.upper())
+        except KeyError:
+            return cls(None)
+
+
+class RunCode(Enum, metaclass=MissingItem):
     INVALID = -1
     DAILY = 1
     WEEKLY = 2
@@ -21,7 +29,7 @@ class RunCode(Enum):
         return RunCode.DAILY
 
 
-class Mode(Enum):
+class Mode(Enum, metaclass=MissingItem):
     MANUAL = 0
     FROZEN = 1
     AUTOPILOT = 2
@@ -31,7 +39,7 @@ class Mode(Enum):
         return Mode.MANUAL
 
 
-class Permission(Enum):
+class Permission(Enum, metaclass=MissingItem):
     INVALID = -1
     ADMIN = 0
     EXECUTIVE = 1
@@ -136,7 +144,7 @@ class DOS(Enum):
             return cls.none.value
 
 
-class Control(Enum):
+class Control(Enum, metaclass=MissingItem):
     INVALID = -1
     NONE = 0
     CROWDSTRIKE = 1
@@ -150,7 +158,7 @@ class Control(Enum):
         return Control.INVALID
 
 
-class AuditEvent(Enum):
+class AuditEvent(Enum, metaclass=MissingItem):
     INVALID = 0
     ATTACH_PARTNER = 1
     CREATE_TEST = 2


### PR DESCRIPTION
* have sdk take enum params instead of ints
* sdk then sends string names instead of ints to API

* **Added EnumMeta to our codes:** By default a non-existent enum string  will throw a KeyError. The EnumMeta `__getitem__` will catch that error and redirect to the normal enum constructor.
   * so anything using ints will continue to work (backwards compatible woo) (ex. `RunCode[2]` is `RunCode.WEEKLY`)
   * and non-existent string will  fall through to the `__missing__` method (ex. `RunCode['mahinas-birthday']` will be `RunCode.DAILY`)

with https://github.com/preludeorg/service/pull/1448