### PR TITLE
Adding random command selection function to Endpoint

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -143,6 +143,20 @@ func Shell(args []string) (string, error) {
 	return string(stdout), nil
 }
 
+func ExecuteRandomCommand(commands [][]string) (string, error) {
+	var command []string
+	if len(commands) == 0 {
+		return "", fmt.Errorf("command slice is empty")
+	} else if len(commands) == 1 {
+		command = commands[0]
+	} else {
+		index := rand.Intn(len(commands))
+		command = commands[index]
+	}
+
+	return Shell(command)
+}
+
 func IsAvailable(programs ...string) bool {
 	for _, program := range programs {
 		_, err := exec.LookPath(program)


### PR DESCRIPTION
An increasing number of our tests rely on the following pattern to execute a randomly selected command on each test execution.

```go
func check() {
    commands := [][]string{
        {"cmd.exe", "/C", "foo.exe bar"},
        {"cmd.exe", "/C", "c:\Windows\System32\bar.exe 123"},
        { "powershell.exe", "-c", "Get-Foobar" },
    }
    index := rand.Intn(len(commands))
    command := commands[randomIndex]
    Endpoint.Shell(command)
}
```

This is a valuable feature of our tests as it lets us extend a give test to exercise multiple variations of the same operation. To reduce code reuse and standardize our implementation (no more `math/rand` vs `crypto/rand`), this new Endpoint function abstracts command selection away from the developer and leverages the exists, tested `Shell` function to execute the randomly chosen command. 