### PR TITLE
DET-832: remove guard so we download files without suffixes

### DIFF
--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -80,10 +80,9 @@ def download(controller, test):
         attachments = controller.get_test(test_id=test).get('attachments')
 
         for attach in attachments:
-            if Path(attach).suffix:
-                code = controller.download(test_id=test, filename=attach)
-                with open(PurePath(test, attach), 'wb') as f:
-                    f.write(code)
+            code = controller.download(test_id=test, filename=attach)
+            with open(PurePath(test, attach), 'wb') as f:
+                f.write(code)
 
 
 @detect.command('enable-test')

--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -169,10 +169,9 @@ def clone(controller):
         Path(test['id']).mkdir(parents=True, exist_ok=True)
 
         for attach in controller.get_test(test_id=test['id']).get('attachments'):
-            if Path(attach).suffix:
-                code = controller.download(test_id=test['id'], filename=attach)
-                with open(PurePath(test['id'], attach), 'wb') as f:
-                    f.write(code)
+            code = controller.download(test_id=test['id'], filename=attach)
+            with open(PurePath(test['id'], attach), 'wb') as f:
+                f.write(code)
 
     async def start_cloning():
         await asyncio.gather(*[fetch(test) for test in controller.list_tests()])


### PR DESCRIPTION
About the only issue I could see here, would be if we started supported directories in tests. But I really don't want to think about that right now, and this is a demonstrated problem on an existing us2 test. Also, if we ever want to push 0fe330f2-7a9c-48c0-a268-5600b4a15ea7 to us1, we won't get that file. 
