### PR TITLE
Bug: Fix race condition in ScanHosts (Network)

### DIFF
--- a/go/tests/network/network.go
+++ b/go/tests/network/network.go
@@ -296,8 +296,8 @@ func (s *PortScan) ScanHosts(ports ...int) []string {
 					go func(host string, port int) {
 						defer wg.Done()
 						if s.ScanPort("tcp", host, port) {
-							hostArray = append(hostArray, host)
 							mutex.Lock()
+							hostArray = append(hostArray, host)
 							fmt.Printf("[+] Host: %s is up on port %d\n", host, port)
 							mutex.Unlock()
 						}


### PR DESCRIPTION
This commit addresses a race condition in the ScanHosts function where multiple goroutines were concurrently appending to hostArray and printing to the console without proper synchronization.