### PR TITLE
Template README On Test Creation

### DIFF
--- a/javascript/sdk/test/sdk.test.ts
+++ b/javascript/sdk/test/sdk.test.ts
@@ -151,7 +151,7 @@ describe("SDK Test", () => {
       data = data.replace("$ID", testId);
       data = data.replace("$NAME", testName);
       data = data.replace("$UNIT", testUnit);
-      data = data.replace("$CREATED", new Date().toISOString());
+      data = data.replace("$TIME", new Date().toISOString());
       const response = await service.build.upload(testId, templateName, data);
       expect(response).toHaveProperty("id");
       expect(response.id.length).toEqual(36);

--- a/javascript/sdk/test/templates/template.go
+++ b/javascript/sdk/test/templates/template.go
@@ -2,7 +2,7 @@
 ID: $ID
 NAME: $NAME
 UNIT: $UNIT
-CREATED: $CREATED
+CREATED: $TIME
 */
 package main
 

--- a/python/cli/prelude_cli/templates/README.md
+++ b/python/cli/prelude_cli/templates/README.md
@@ -1,0 +1,28 @@
+# $NAME
+
+This section should provide a description of the test, providing some background information (such as historical in-the-wild usage by threat actors or APTs), as well as briefly illustrating the test's intention, objective, and techniques utilized to achieve them. This section should NOT be too technical or overly long; a small paragraph should be sufficient.
+
+## How
+
+> Safety: This section should contain a kind of advisory statement which positively declares that the VST does not actually negatively affect the tested system in any way.
+
+Steps:
+
+1. This section enumerates the individual, atomic steps by which ...
+2. ... the probe attempts to achieve the intended effect of the test ...
+3. ... and thereby perform evaluation of any resident security solutions.
+
+Example Output:
+```bash
+[$ID] Starting test at: $TIME
+[$ID] Host is vulnerable, continuing with technique execution
+[$ID] Completed with code: 101
+[$ID] Ending test at: $TIME
+```
+
+## Resolution
+
+If this test fails:
+
+* Bulleted list of recommendations that the testing organization SHOULD consider ...
+* ... based upon the nature of the test, as well as the point of failure.

--- a/python/cli/prelude_cli/templates/template.go
+++ b/python/cli/prelude_cli/templates/template.go
@@ -2,7 +2,7 @@
 ID: $ID
 NAME: $NAME
 UNIT: $UNIT
-CREATED: $CREATED
+CREATED: $TIME
 */
 package main
 

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -36,7 +36,7 @@ def create_test(controller, name, unit, test, techniques, advisory):
         utc_time = str(datetime.now(timezone.utc))
         template_body = pkg_resources.read_text(templates, template)
         template_body = template_body.replace('$ID', t['id'])
-        template_body = template_body.replace('$NAME', name)
+        template_body = template_body.replace('$NAME', t['name'])
         template_body = template_body.replace('$UNIT', unit or '')
         template_body = template_body.replace('$TIME', utc_time)
         

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -61,6 +61,8 @@ def create_test(controller, name, unit, test, techniques, advisory):
         with open(test_dir, 'w', encoding='utf8') as test_code:
             test_code.write(testTemplate)
 
+        print_json(data=t)
+
         """ Mark up, upload, and write the test README template. """
         readmeTemplate = pkg_resources.read_text(templates, 'README.md')
         readmeTemplate = readmeTemplate.replace('$NAME', name)
@@ -70,7 +72,9 @@ def create_test(controller, name, unit, test, techniques, advisory):
         with Spinner(description='Applying default template to new test'):
             controller.upload(test_id=t['id'], filename='README.md', data=readmeTemplate.encode('utf-8'))
 
-        with open(test_dir, 'w', encoding='utf8') as test_readme:
+        readme_dir = PurePath(t['id'], 'README.md')
+
+        with open(readme_dir, 'w', encoding='utf8') as test_readme:
             test_readme.write(readmeTemplate)
             t['attachments'] = ['README.md']
 

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -43,25 +43,24 @@ def create_test(controller, name, unit, test, techniques, advisory):
 
     def create_template(template, name):
         utc_time = str(datetime.now(timezone.utc))
-        template = pkg_resources.read_text(templates, template)
-        template = template.replace('$ID', t['id'])
-        template = template.replace('$NAME', name)
-        template = template.replace('$UNIT', unit or '')
-        template = template.replace('$TIME', utc_time)
+        template_body = pkg_resources.read_text(templates, template)
+        template_body = template_body.replace('$ID', t['id'])
+        template_body = template_body.replace('$NAME', name)
+        template_body = template_body.replace('$UNIT', unit or '')
+        template_body = template_body.replace('$TIME', utc_time)
         
         with Spinner(description='Applying default template to new test'):
-            controller.upload(test_id=t['id'], filename=name, data=template.encode('utf-8'))
+            controller.upload(test_id=t['id'], filename=name, data=template_body.encode('utf-8'))
             t['attachments'] += [name]
 
         dir = PurePath(t['id'], name)
-        Path(t['id']).mkdir(parents=True, exist_ok=True)
         
         with open(dir, 'w', encoding='utf8') as code:
-            code.write(template)
+            code.write(template_body)
 
     if not test:
-        basename = f'{t["id"]}.go'
-        create_template(template='template.go', name=basename)
+        Path(t['id']).mkdir(parents=True, exist_ok=True)
+        create_template(template='template.go', name=f'{t["id"]}.go')
         create_template(template='README.md', name='README.md')
 
     print_json(data=t)

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -31,6 +31,7 @@ def build(ctx):
 @click.pass_obj
 @handle_api_error
 def create_test(controller, name, unit, test, techniques, advisory):
+    """ Create or update a security test """
     def create_template(template, name):
         utc_time = str(datetime.now(timezone.utc))
         template_body = pkg_resources.read_text(templates, template)
@@ -39,7 +40,6 @@ def create_test(controller, name, unit, test, techniques, advisory):
         template_body = template_body.replace('$UNIT', unit or '')
         template_body = template_body.replace('$TIME', utc_time)
 
-    """ Create or update a security test """
     with Spinner(description='Creating new test'):
         t = controller.create_test(
             name=name,

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -5,7 +5,7 @@ import prelude_cli.templates as templates
 import importlib.resources as pkg_resources
 
 from rich import print_json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path, PurePath
 
 from prelude_cli.views.shared import handle_api_error, Spinner
@@ -44,7 +44,7 @@ def create_test(controller, name, unit, test, techniques, advisory):
     if not test:
         """ Mark-up, upload, and write the test file template. """
         basename = f'{t["id"]}.go'
-        utc_time = str(datetime.utcnow())
+        utc_time = str(datetime.now(timezone.utc))
         test_template = pkg_resources.read_text(templates, 'template.go')
         test_template = test_template.replace('$ID', t['id'])
         test_template = test_template.replace('$NAME', name)

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -39,15 +39,6 @@ def create_test(controller, name, unit, test, techniques, advisory):
         template_body = template_body.replace('$NAME', name)
         template_body = template_body.replace('$UNIT', unit or '')
         template_body = template_body.replace('$TIME', utc_time)
-
-    with Spinner(description='Creating new test'):
-        t = controller.create_test(
-            name=name,
-            unit=unit,
-            test_id=test,
-            techniques=techniques,
-            advisory=advisory
-        )
         
         with Spinner(description='Applying default template to new test'):
             controller.upload(test_id=t['id'], filename=name, data=template_body.encode('utf-8'))
@@ -57,6 +48,15 @@ def create_test(controller, name, unit, test, techniques, advisory):
         
         with open(dir, 'w', encoding='utf8') as code:
             code.write(template_body)
+
+    with Spinner(description='Creating new test'):
+        t = controller.create_test(
+            name=name,
+            unit=unit,
+            test_id=test,
+            techniques=techniques,
+            advisory=advisory
+        )
 
     if not test:
         Path(t['id']).mkdir(parents=True, exist_ok=True)

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -37,7 +37,7 @@ def create_test(controller, name, unit, test, techniques, advisory):
         template_body = pkg_resources.read_text(templates, template)
         template_body = template_body.replace('$ID', t['id'])
         template_body = template_body.replace('$NAME', t['name'])
-        template_body = template_body.replace('$UNIT', unit or '')
+        template_body = template_body.replace('$UNIT', t['unit'])
         template_body = template_body.replace('$TIME', utc_time)
         
         with Spinner(description='Applying default template to new test'):

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 import click
-import prelude_cli.testTemplates as testTemplates
+import prelude_cli.templates as templates
 import importlib.resources as pkg_resources
 
 from rich import print_json

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -44,38 +44,38 @@ def create_test(controller, name, unit, test, techniques, advisory):
     if not test:
         """ Mark-up, upload, and write the test file template. """
         basename = f'{t["id"]}.go'
-        utcTime = str(datetime.utcnow())
-        testTemplate = pkg_resources.read_text(templates, 'template.go')
-        testTemplate = testTemplate.replace('$ID', t['id'])
-        testTemplate = testTemplate.replace('$NAME', name)
-        testTemplate = testTemplate.replace('$UNIT', unit or '')
-        testTemplate = testTemplate.replace('$CREATED', utcTime)
+        utc_time = str(datetime.utcnow())
+        test_template = pkg_resources.read_text(templates, 'template.go')
+        test_template = test_template.replace('$ID', t['id'])
+        test_template = test_template.replace('$NAME', name)
+        test_template = test_template.replace('$UNIT', unit or '')
+        test_template = test_template.replace('$CREATED', utc_time)
         
         with Spinner(description='Applying default template to new test'):
-            controller.upload(test_id=t['id'], filename=basename, data=testTemplate.encode('utf-8'))
+            controller.upload(test_id=t['id'], filename=basename, data=test_template.encode('utf-8'))
             t['attachments'] = [basename]
 
         test_dir = PurePath(t['id'], basename)
         Path(t['id']).mkdir(parents=True, exist_ok=True)
         
         with open(test_dir, 'w', encoding='utf8') as test_code:
-            test_code.write(testTemplate)
+            test_code.write(test_template)
 
         print_json(data=t)
 
         """ Mark up, upload, and write the test README template. """
-        readmeTemplate = pkg_resources.read_text(templates, 'README.md')
-        readmeTemplate = readmeTemplate.replace('$NAME', name)
-        readmeTemplate = readmeTemplate.replace('$ID', t['id'])
-        readmeTemplate = readmeTemplate.replace('$TIME', utcTime)
+        readme_template = pkg_resources.read_text(templates, 'README.md')
+        readme_template = readme_template.replace('$NAME', name)
+        readme_template = readme_template.replace('$ID', t['id'])
+        readme_template = readme_template.replace('$TIME', utc_time)
 
         with Spinner(description='Applying default template to new test'):
-            controller.upload(test_id=t['id'], filename='README.md', data=readmeTemplate.encode('utf-8'))
+            controller.upload(test_id=t['id'], filename='README.md', data=readme_template.encode('utf-8'))
 
         readme_dir = PurePath(t['id'], 'README.md')
 
         with open(readme_dir, 'w', encoding='utf8') as test_readme:
-            test_readme.write(readmeTemplate)
+            test_readme.write(readme_template)
             t['attachments'] = ['README.md']
 
     print_json(data=t)

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -31,6 +31,14 @@ def build(ctx):
 @click.pass_obj
 @handle_api_error
 def create_test(controller, name, unit, test, techniques, advisory):
+    def create_template(template, name):
+        utc_time = str(datetime.now(timezone.utc))
+        template_body = pkg_resources.read_text(templates, template)
+        template_body = template_body.replace('$ID', t['id'])
+        template_body = template_body.replace('$NAME', name)
+        template_body = template_body.replace('$UNIT', unit or '')
+        template_body = template_body.replace('$TIME', utc_time)
+
     """ Create or update a security test """
     with Spinner(description='Creating new test'):
         t = controller.create_test(
@@ -40,14 +48,6 @@ def create_test(controller, name, unit, test, techniques, advisory):
             techniques=techniques,
             advisory=advisory
         )
-
-    def create_template(template, name):
-        utc_time = str(datetime.now(timezone.utc))
-        template_body = pkg_resources.read_text(templates, template)
-        template_body = template_body.replace('$ID', t['id'])
-        template_body = template_body.replace('$NAME', name)
-        template_body = template_body.replace('$UNIT', unit or '')
-        template_body = template_body.replace('$TIME', utc_time)
         
         with Spinner(description='Applying default template to new test'):
             controller.upload(test_id=t['id'], filename=name, data=template_body.encode('utf-8'))

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -68,10 +68,11 @@ def create_test(controller, name, unit, test, techniques, advisory):
         readmeTemplate = readmeTemplate.replace('$TIME', utcTime)
 
         with Spinner(description='Applying default template to new test'):
-            controller.upload(test_id=t['id'], filename=basename, data=readmeTemplate.encode('utf-8'))
+            controller.upload(test_id=t['id'], filename='README.md', data=readmeTemplate.encode('utf-8'))
 
         with open(test_dir, 'w', encoding='utf8') as test_readme:
             test_readme.write(readmeTemplate)
+            t['attachments'] = ['README.md']
 
     print_json(data=t)
 

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -5,8 +5,8 @@ import prelude_cli.templates as templates
 import importlib.resources as pkg_resources
 
 from rich import print_json
-from datetime import datetime, timezone
 from pathlib import Path, PurePath
+from datetime import datetime, timezone
 
 from prelude_cli.views.shared import handle_api_error, Spinner
 from prelude_sdk.controllers.build_controller import BuildController
@@ -42,7 +42,6 @@ def create_test(controller, name, unit, test, techniques, advisory):
         )
 
     if not test:
-        """ Mark-up, upload, and write the test file template. """
         basename = f'{t["id"]}.go'
         utc_time = str(datetime.now(timezone.utc))
         test_template = pkg_resources.read_text(templates, 'template.go')
@@ -61,9 +60,6 @@ def create_test(controller, name, unit, test, techniques, advisory):
         with open(test_dir, 'w', encoding='utf8') as test_code:
             test_code.write(test_template)
 
-        print_json(data=t)
-
-        """ Mark up, upload, and write the test README template. """
         readme_template = pkg_resources.read_text(templates, 'README.md')
         readme_template = readme_template.replace('$NAME', name)
         readme_template = readme_template.replace('$ID', t['id'])
@@ -76,7 +72,7 @@ def create_test(controller, name, unit, test, techniques, advisory):
 
         with open(readme_dir, 'w', encoding='utf8') as test_readme:
             test_readme.write(readme_template)
-            t['attachments'] = ['README.md']
+            t['attachments'] += ['README.md']
 
     print_json(data=t)
 


### PR DESCRIPTION
Added functionality to the cli's `build` feature that writes a templated `README.md` markdown file (also included in this update) to the new test's directory when a user creates a new test with `prelude build create-test <opts>`.

Currently, this functionality is broken up for readability, but can be condensed if need be, for example by combining both file writes into one `with open` call. I think it should probably remain separated, though.

Sample cli output screens: 
![Screenshot 2023-12-08 210558](https://github.com/preludeorg/libraries/assets/152905299/cded79d3-cd10-4e00-b088-3b1d249052f3)
![Screenshot 2023-12-08 210610](https://github.com/preludeorg/libraries/assets/152905299/05ac0d8c-5926-4fe0-bc90-aee12c919125)
