### PR TITLE
Added Wait() function. Added timestamping to Say(). Housekeeping.

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -77,10 +77,10 @@ func Stop(code int) {
 // NB: time.Duration is an int64 cast
 func Wait(dur time.Duration) {
 	if dur <= 0 { // default
-		Say("Waiting for 3 seconds.")
+		Say("Waiting for 3 seconds")
 		time.Sleep(3 * time.Second)
 	} else {
-		Say(fmt.Sprintf("Waiting for %d seconds.", dur))
+		Say(fmt.Sprintf("Waiting for %d seconds", dur))
 		time.Sleep(dur * time.Second)
 	}
 }


### PR DESCRIPTION
In this PR:
- Added the `Wait()` function to `endpoint.go`. This function when called pauses the test for time `dur`. If `dur` is passed as <= 0, `Wait()` pauses for 3 seconds (as a hack default value). Else it pauses for `dur` seconds.
- Added timestamp functionality to `Say()`. Now, a timestamp is prepended to each and every logged message. The goal of this change is to enable customers to easily cross-reference event/activity times observed in their SIEM with those pronounced by the test, providing valuable information usable in solution tuning, test activity attribution, etc.
-- Before: 
![Screenshot 2024-01-02 130303](https://github.com/preludeorg/tests/assets/152905299/1352fc7c-ac38-49df-ad52-7fa82bf494f1)
-- After: 
![Screenshot 2024-01-02 130331](https://github.com/preludeorg/tests/assets/152905299/13e08644-c18b-4635-a704-b2b2ca3e1b0a)
-- The timestamp format is currently set to the same format seen on the test start-stop messages. This is for consistency.
- Moved the const var decls to the top of the source code body.