### PR TITLE
det-975: get probe sleep interval from BE

### DIFF
--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -24,10 +24,6 @@ do
         sleep ${sleep_sec:-1800}
 
         # Option 2. try/catch method. I couldn't find a way to do sneaky bash injection, and this might is probably slightly more efficient
-        sleep $task 2>/dev/null
-        if [ $? = 1 ];then
-          echo "Invalid sleep time: $task"
-          sleep 1800
-        fi
+        sleep $task 2>/dev/null || (echo "Invalid sleep time: $task" && sleep 1800)
     fi
 done

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -5,7 +5,7 @@ vst='.vst'
 
 while :
 do
-    task=$(curl -sf -H "token:${PRELUDE_TOKEN}" -H "dos:$(uname -s)-$(uname -m)" -H "dat:${dat}" -H "version:2" https://api.preludesecurity.com)
+    task=$(curl -sf -H "token:${PRELUDE_TOKEN}" -H "dos:$(uname -s)-$(uname -m)" -H "dat:${dat}" -H "version:2.1" https://api.preludesecurity.com)
     uuid=$(echo "$task" | sed -nE 's/.*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*/\1/p')
     auth=$(echo "$task" | sed -nE 's,^[^/]*//([^/]*)/.*,\1,p')
 

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -18,12 +18,7 @@ do
     else
         rm -rf $vst
         unset dat
-
-        # Option 1. Explicitly check that sleep is an int. Otherwise default to 1800s
         sleep_sec=$(echo "$task" | grep -E '^[0-9]+$')
         sleep ${sleep_sec:-1800}
-
-        # Option 2. try/catch method. I couldn't find a way to do sneaky bash injection, and this might is probably slightly more efficient
-        sleep $task 2>/dev/null || (echo "Invalid sleep time: $task" && sleep 1800)
     fi
 done

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -18,6 +18,6 @@ do
     else
         rm -rf $vst
         unset dat
-        sleep 3600
+        sleep $task
     fi
 done

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -18,6 +18,16 @@ do
     else
         rm -rf $vst
         unset dat
-        sleep $task
+
+        # Option 1. Explicitly check that sleep is an int. Otherwise default to 1800s
+        sleep_sec=$(echo "$task" | grep -E '^[0-9]+$')
+        sleep ${sleep_sec:-1800}
+
+        # Option 2. try/catch method. I couldn't find a way to do sneaky bash injection, and this might is probably slightly more efficient
+        sleep $task 2>/dev/null
+        if [ $? = 1 ];then
+          echo "Invalid sleep time: $task"
+          sleep 1800
+        fi
     fi
 done

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -31,7 +31,7 @@ while ($true) {
             "token" = $env:PRELUDE_TOKEN
             "dos" = "windows-$Env:PROCESSOR_ARCHITECTURE"
             "dat" = $dat
-            "version" = "2"
+            "version" = "2.1"
         } -UseBasicParsing -MaximumRedirection 0 -ErrorAction SilentlyContinue
         
         $uuid = $task.content -replace ".*?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*", '$1'

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -50,7 +50,7 @@ while ($true) {
         Write-Output $_.Exception
         Remove-Item $dir -Force -Recurse -ErrorAction SilentlyContinue
         $dat = ""
-        if (-Not (($task.content -as [int])) {
+        if (-Not ($task.content -as [int])) {
             Write-Output "Invalid sleep time: $task"
             $task = 1800
         }

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -50,6 +50,6 @@ while ($true) {
         Write-Output $_.Exception
         Remove-Item $dir -Force -Recurse -ErrorAction SilentlyContinue
         $dat = ""
-        Start-Sleep -Seconds 3600
+        Start-Sleep -Seconds $task
     }
 }

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -41,7 +41,7 @@ while ($true) {
             Invoke-WebRequest -Uri $task.content -OutFile (New-Item -path "$dir\$uuid.exe" -Force ) -UseBasicParsing
             $code = Execute "$dir\$uuid.exe"
             $dat = "${uuid}:${code}"
-        } elseif ($task -eq "stop") {
+        } elseif ($task.content -eq "stop") {
             exit
         } else {
             throw "Test cycle done"
@@ -50,6 +50,10 @@ while ($true) {
         Write-Output $_.Exception
         Remove-Item $dir -Force -Recurse -ErrorAction SilentlyContinue
         $dat = ""
-        Start-Sleep -Seconds $task
+        if (-Not (($task.content -as [int])) {
+            Write-Output "Invalid sleep time: $task"
+            $task = 1800
+        }
+        Start-Sleep -Seconds "$task"
     }
 }


### PR DESCRIPTION
Also, fix upgrade path for raindrop :( 

If when this goes in, I'll update probe_tasks probe version as well to trigger upgrades (for nocturnal anyway)

PR bundle:
- https://github.com/preludeorg/backbone/pull/719
- https://github.com/preludeorg/service/pull/1601
- https://github.com/preludeorg/libraries/pull/934