### PR TITLE
fix: [DET-1022] Fix probe deploy notifcations.

### DIFF
--- a/.github/actions/shell_probes/action.yml
+++ b/.github/actions/shell_probes/action.yml
@@ -67,13 +67,13 @@ runs:
       with:
         payload: |
           {
-            "text": "Probe Deploy (${{ github.triggering_actor }}): ${GITHUB_REF#refs/*/} ${{ job.status }}",
+            "text": "Probe Deploy (${{ github.triggering_actor }}): ${{ github.ref }} - ${{ job.status }}",
             "blocks": [
               {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "Probe Deploy (${{ github.triggering_actor }}): ${GITHUB_REF#refs/*/} ${{ job.status }}"
+                  "text": "Probe Deploy (${{ github.triggering_actor }}): ${{ github.ref }} ${{ job.status }}"
                 }
               }
             ]


### PR DESCRIPTION
The notifcations were using `GITHUB_REF` which is not valid (cf. https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables).

They should use `github.ref`.