### PR TITLE
det-1120: add Threats API sdk tests

### DIFF
--- a/python/sdk/tests/test_iam.py
+++ b/python/sdk/tests/test_iam.py
@@ -51,6 +51,7 @@ class TestIAM:
 
         pytest.account.headers['account'] = res['account_id']
         pytest.account.headers['token'] = res['token']
+        print(f'[account_id: {res["account_id"]}]', end=' ')
 
         pytest.expected_account = dict(
             account_id=res['account_id'],

--- a/python/sdk/tests/test_partner.py
+++ b/python/sdk/tests/test_partner.py
@@ -73,7 +73,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize(argnames, argvalues, ids=idlist, scope="class")
 
 
-@pytest.mark.order(4)
+@pytest.mark.order(5)
 class TestPartner:
     scenarios = [crowdstrike, defender, sentinel_one]
 
@@ -172,7 +172,7 @@ class TestPartner:
             unwrap(self.detect.delete_endpoint)(self.detect, ident=pytest.endpoint_1['endpoint_id'])
 
 
-@pytest.mark.order(5)
+@pytest.mark.order(6)
 class TestSiems:
 
     def setup_class(self):


### PR DESCRIPTION
* move to `schedule/unschedule` instead of `enable/disableTest`
* add Get/ListThreats tests - using a predetermined prelude test might get flakey, but we'll see how it plays out and adjust if necessary
* add one threat in schedule when testing probe