### PR TITLE
fix: fix python sdk test_describe_activity

### DIFF
--- a/python/sdk/tests/test_probe.py
+++ b/python/sdk/tests/test_probe.py
@@ -67,7 +67,7 @@ class TestProbe:
                 endpoints=pytest.endpoint_id
             )
             res = unwrap(self.detect.describe_activity)(self.detect, view='logs', filters=filters)
-            assert 7 == len(res), json.dumps(res, indent=2)
+            assert 5 == len(res), json.dumps(res, indent=2)
         finally:
             os.remove(pytest.probe_file)
 


### PR DESCRIPTION
I think I'd just written this expectation before I decided to create a new endpoint just for the probe (so the 7 was including tests that ran earlier in the test suite on different endpoint)