### PR TITLE
det-1130: add test for purging a test

### DIFF
--- a/python/sdk/tests/test_build.py
+++ b/python/sdk/tests/test_build.py
@@ -108,13 +108,20 @@ class TestBuild:
 
     @pytest.mark.order(-2)
     def test_delete_test(self, unwrap):
-        unwrap(self.build.delete_test)(self.build, test_id=pytest.test_id)
+        unwrap(self.build.delete_test)(self.build, test_id=pytest.test_id, purge=False)
         res = unwrap(self.detect.get_test)(self.detect, test_id=pytest.test_id)
         pytest.expected_test['tombstoned'] = res['tombstoned']
 
         diffs = check_dict_items(pytest.expected_test, res)
         assert not diffs, json.dumps(diffs, indent=2)
         assert parse(res['tombstoned']) <= datetime.utcnow() + timedelta(minutes=1)
+
+    def test_purge_test(self, unwrap):
+        purge_test_id = str(uuid.uuid4())
+        unwrap(self.build.create_test)(self.build, test_id=purge_test_id, name=self.name, unit=self.unit)
+        unwrap(self.build.delete_test)(self.build, test_id=purge_test_id, purge=True)
+        with pytest.raises(Exception):
+            unwrap(self.detect.get_test)(self.detect, test_id=purge_test_id)
 
 
 @pytest.mark.order(3)

--- a/python/sdk/tests/test_build.py
+++ b/python/sdk/tests/test_build.py
@@ -116,12 +116,9 @@ class TestBuild:
         assert not diffs, json.dumps(diffs, indent=2)
         assert parse(res['tombstoned']) <= datetime.utcnow() + timedelta(minutes=1)
 
-    def test_purge_test(self, unwrap):
-        purge_test_id = str(uuid.uuid4())
-        unwrap(self.build.create_test)(self.build, test_id=purge_test_id, name=self.name, unit=self.unit)
-        unwrap(self.build.delete_test)(self.build, test_id=purge_test_id, purge=True)
+        unwrap(self.build.delete_test)(self.build, test_id=pytest.test_id, purge=True)
         with pytest.raises(Exception):
-            unwrap(self.detect.get_test)(self.detect, test_id=purge_test_id)
+            unwrap(self.detect.get_test)(self.detect, test_id=pytest.test_id)
 
 
 @pytest.mark.order(3)

--- a/python/sdk/tests/test_iam.py
+++ b/python/sdk/tests/test_iam.py
@@ -75,7 +75,7 @@ class TestIAM:
                     tag='autopilot'
                 )
             ],
-            probe_sleep='1800s',
+            probe_sleep='600s',
             oidc=dict(),
             oidc_enabled=False
         )


### PR DESCRIPTION
* test purging a test
* fix existing test tombstone test
* fix expected probe sleep time in iam test

I didn't add a test for deleting/purging a threat because everything in the SDK threats appears to be done as a regular user test and threats can only be created / deleted by the prelude account. Looks like there are no create threat tests in there already and I assumed that is why. If that assumption is incorrect let me know and I'll see about adding some tests around threats.