### PR TITLE
fix python sdk tests

### DIFF
--- a/python/sdk/tests/test_build.py
+++ b/python/sdk/tests/test_build.py
@@ -138,7 +138,7 @@ class TestThreat:
             account_id='prelude',
             id=self.threat_id,
             source_id='aa23-061a',
-            name='User Execution of Malicious File, Ransomware Data Encryption (#StopRansomware: Royal Ransomware)',
+            name='#StopRansomware: Royal Ransomware',
             source='https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-061a',
             published='2023-11-13',
             tests=['881f9052-fb52-4daf-9ad2-0a7ad9615baf', 'b74ad239-2ddd-4b1e-b608-8397a43c7c54'],

--- a/python/sdk/tests/test_probe.py
+++ b/python/sdk/tests/test_probe.py
@@ -32,12 +32,12 @@ class TestProbe:
         unwrap(self.detect.schedule)(
             self.detect,
             [
-                dict(test_id='2e705bac-a889-4283-9a8e-a12358fa1d09', run_code=RunCode.DEBUG.name, tags=''),
+                dict(test_id='9f410a6b-76b6-45d6-b80f-d7365add057e', run_code=RunCode.DEBUG.name, tags=''),
                 dict(test_id='b74ad239-2ddd-4b1e-b608-8397a43c7c54', run_code=RunCode.RUN_ONCE.name, tags=''),
                 # 2 tests in this threat (881.., b74...)
                 dict(threat_id=pytest.threat_id, run_code=RunCode.DAILY.name, tags=''),
                 # windows only test
-                dict(test_id='9db16ec3-1412-4a6b-9417-81d17790e55f', run_code=RunCode.DEBUG.name, tags=''),
+                dict(test_id='f12d00db-571f-4c51-a536-12a3577b5a4b', run_code=RunCode.DEBUG.name, tags=''),
                 # should not run
                 dict(test_id='8f9558f3-d451-46e3-bdda-97378c1e8ce4', run_code=RunCode.DAILY.name, tags='diff-tag')
             ]
@@ -76,10 +76,10 @@ class TestProbe:
         unwrap(self.detect.unschedule)(
             self.detect,
             [
-                dict(test_id='2e705bac-a889-4283-9a8e-a12358fa1d09', tags=''),
+                dict(test_id='9f410a6b-76b6-45d6-b80f-d7365add057e', tags=''),
                 dict(test_id='b74ad239-2ddd-4b1e-b608-8397a43c7c54', tags=''),
                 dict(threat_id=pytest.threat_id, tags=''),
-                dict(test_id='9db16ec3-1412-4a6b-9417-81d17790e55f', tags=''),
+                dict(test_id='f12d00db-571f-4c51-a536-12a3577b5a4b', tags=''),
                 dict(test_id='8f9558f3-d451-46e3-bdda-97378c1e8ce4', tags='diff-tag')
             ]
         )


### PR DESCRIPTION
these tests rely on real prelude tests in us2 - things are achangin; this PR catches the tests up to speed