### PR TITLE
Use context to manage timeouts

### DIFF
--- a/go/tests/endpoint/go.mod
+++ b/go/tests/endpoint/go.mod
@@ -1,3 +1,3 @@
-module github.com/preludeorg/libraries/go/tests/endpoint
+module github.com/preludeorg/libraries/go/tests/endpoint/v2
 
 go 1.21


### PR DESCRIPTION
* pass a context with a timeout to start
* pass the context to exec.CommandContext so the child process is killed on timeout