### PR TITLE
Network.go: updating http request timeout default to 10

### DIFF
--- a/go/tests/network/network.go
+++ b/go/tests/network/network.go
@@ -47,7 +47,7 @@ type ResponseData struct {
 
 func NewHTTPRequest(requestURL string, opts *RequestOptions) *Requester {
 
-	timeout := time.Second * 1
+	timeout := time.Second * 10
 	userAgent := "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0"
 
 	if opts != nil {


### PR DESCRIPTION
Bringing this up to a more acceptable level. see: https://detectors.atlassian.net/browse/DET-1440 