### PR TITLE
det-1491: add --output_file flag to GetDetection CLI

### DIFF
--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -1,5 +1,6 @@
 import asyncio
 import click
+import yaml
 
 from datetime import datetime, time, timedelta, timezone
 from dateutil.parser import parse
@@ -106,12 +107,16 @@ def list_detections(controller):
 
 @detect.command('detection')
 @click.argument('detection_id')
+@click.option('-o', '--output_file', help='write the sigma rule to a file', type=click.Path(writable=True))
 @click.pass_obj
 @handle_api_error
-def get_detection(controller, detection_id):
+def get_detection(controller, detection_id, output_file):
     """ List properties for a detection """
     with Spinner(description='Fetching data for detection'):
         data = controller.get_detection(detection_id=detection_id)
+    if output_file:
+        with open(output_file, 'w') as f:
+            f.write(yaml.safe_dump(data['rule']))
     print_json(data=data)
 
 

--- a/python/cli/setup.cfg
+++ b/python/cli/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     click > 8
     rich
     python-dateutil
+    pyyaml
 [options.entry_points]
 console_scripts =
     prelude = prelude_cli.cli:cli


### PR DESCRIPTION
The CLI printout of the sigma rule shows a sigma rule detection like 
```
"ParentImage": [
  ".*\\s+Hi\\\\\\\\cmd.exe"
]
```
b/c printing a dictionary apparently calls `_repr_` not `_str_`

Writing the detection to a file will show the strings correctly (`.*\s+Hi\\\\cmd.exe`) and also, a yaml file is how you call Create and UpdateDetection, so it makes that flow easier too