### PR TITLE
cleanup: log missing Exitcode as string

### DIFF
--- a/python/sdk/prelude_sdk/models/codes.py
+++ b/python/sdk/prelude_sdk/models/codes.py
@@ -84,7 +84,7 @@ class ExitCode(Enum):
     def _missing_(cls, value):
         if value and not isinstance(value, int):
             return cls(int(value))
-        logging.warning('Unknown ExitCode: %d', value)
+        logging.warning('Unknown ExitCode: %s', str(value))
         return ExitCode.MISSING
 
     @property


### PR DESCRIPTION
In error cases, we get empty string exit codes, so this is just to avoid the uncaught exception of
```
TypeError: %d format: a real number is required, not str
```