### PR TITLE
fix/bash probe

### DIFF
--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -16,6 +16,7 @@ do
         while kill -0 $test_pid 2>/dev/null; do
           if [ $elapsed_time -ge 60 ]; then
             kill -9 $test_pid 2> /dev/null
+            echo "TIMEOUT: Killed long running test ${uuid}"
             code=102
           fi
           sleep 1
@@ -26,6 +27,7 @@ do
           code=$?
         fi
         dat="${uuid}:$([ -f $vst/$uuid ] && echo $code || echo 127)"
+        unset code
     elif [ "$task" = "stop" ];then
         exit
     else

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -13,7 +13,7 @@ do
         curl -sf --max-redirs 0 --create-dirs -o $vst/$uuid $task
         chmod +x $vst/$uuid && $vst/$uuid & test_pid=$!
         elapsed_time=0
-        while kill -0 $test_pid 2>/dev/null; do
+        while kill -0 $test_pid 2> /dev/null; do
           if [ $elapsed_time -ge 60 ]; then
             kill -9 $test_pid 2> /dev/null
             echo "TIMEOUT: Killed long running test ${uuid}"

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -14,12 +14,14 @@ do
 
     if [ "$uuid" ] && [ "$auth" = "$ca" ];then
         curl -sf --max-redirs 0 --create-dirs -o $vst/$uuid $task
-        chmod +x $vst/$uuid && $vst/$uuid & test_pid=$!
+        chmod +x $vst/$uuid
+        $vst/$uuid & test_pid=$!
         elapsed_time=0
         while kill -0 $test_pid 2> /dev/null; do
           if [ $elapsed_time -ge 45 ]; then
+            disown $test_pid
             kill -9 $test_pid 2> /dev/null
-            echo "TIMEOUT: Killed long running test ${uuid}"
+            echo "TIMEOUT: Killed long running test ${uuid} (${test_pid})"
             code=102
           fi
           sleep 1

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -10,12 +10,10 @@ do
     auth=$(echo "$task" | sed -nE 's,^[^/]*//([^/]*)/.*,\1,p')
 
     if [ "$uuid" ] && [ "$auth" = "$ca" ];then
-        echo "${uuid}"
         curl -sf --create-dirs -o $vst/$uuid $task
         chmod +x $vst/$uuid && $vst/$uuid & test_pid=$!
         elapsed_time=0
         while kill -0 $test_pid 2>/dev/null; do
-          echo "into while"
           if [ $elapsed_time -ge 60 ]; then
             kill -9 $test_pid 2> /dev/null
             code=102

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -14,7 +14,7 @@ do
         chmod +x $vst/$uuid && $vst/$uuid & test_pid=$!
         elapsed_time=0
         while kill -0 $test_pid 2> /dev/null; do
-          if [ $elapsed_time -ge 60 ]; then
+          if [ $elapsed_time -ge 45 ]; then
             kill -9 $test_pid 2> /dev/null
             echo "TIMEOUT: Killed long running test ${uuid}"
             code=102

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ca=${PRELUDE_CA:-prelude-account-us1-us-east-2.s3.amazonaws.com}
-vst='.vst'
+vst=${PRELUDE_DIR:-.vst}
 
 while :
 do

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -5,13 +5,28 @@ vst='.vst'
 
 while :
 do
-    task=$(curl -sf -H "token:${PRELUDE_TOKEN}" -H "dos:$(uname -s)-$(uname -m)" -H "dat:${dat}" -H "version:2.1" https://api.preludesecurity.com)
+    task=$(curl -sf -H "token:${PRELUDE_TOKEN}" -H "dos:$(uname -s)-$(uname -m)" -H "dat:${dat}" -H "version:2.2" https://api.preludesecurity.com)
     uuid=$(echo "$task" | sed -nE 's/.*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}).*/\1/p')
     auth=$(echo "$task" | sed -nE 's,^[^/]*//([^/]*)/.*,\1,p')
 
     if [ "$uuid" ] && [ "$auth" = "$ca" ];then
+        echo "${uuid}"
         curl -sf --create-dirs -o $vst/$uuid $task
-        chmod +x $vst/$uuid && $vst/$uuid; code=$?
+        chmod +x $vst/$uuid && $vst/$uuid & test_pid=$!
+        elapsed_time=0
+        while kill -0 $test_pid 2>/dev/null; do
+          echo "into while"
+          if [ $elapsed_time -ge 60 ]; then
+            kill -9 $test_pid 2> /dev/null
+            code=102
+          fi
+          sleep 1
+          elapsed_time=$((elapsed_time + 1))
+        done
+        if [[ $code -ne 102 ]]; then
+          wait $test_pid
+          code=$?
+        fi
         dat="${uuid}:$([ -f $vst/$uuid ] && echo $code || echo 127)"
     elif [ "$task" = "stop" ];then
         exit


### PR DESCRIPTION
`chmod +x $vst/$uuid && $vst/$uuid & test_pid=$!`
was creating a subshell behavior, and $! was actually the pid of the subshell not the test

disown is a bash build in for job control. if you don't disown the pid before you kill it, you get a "gross" signal output
```
TIMEOUT: Killed long running test 0c7fe114-60e9-456b-81d5-21fe673ae3c4
nocturnal.sh: line 42:  3110 Killed                  $vst/$uuid
```
