### PR TITLE
add flag to GetDetection to print sigma rule as yaml

### DIFF
--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -107,17 +107,22 @@ def list_detections(controller):
 
 @detect.command('detection')
 @click.argument('detection_id')
-@click.option('-o', '--output_file', help='write the sigma rule to a file', type=click.Path(writable=True))
+@click.option('-s', '--sigma_only', help='output the sigma rule only in yaml format', is_flag=True)
+@click.option('-o', '--output_file', help='write the sigma rule to a file in yaml format', type=click.Path(writable=True))
 @click.pass_obj
 @handle_api_error
-def get_detection(controller, detection_id, output_file):
+def get_detection(controller, detection_id, sigma_only, output_file):
     """ List properties for a detection """
     with Spinner(description='Fetching data for detection'):
         data = controller.get_detection(detection_id=detection_id)
     if output_file:
         with open(output_file, 'w') as f:
             f.write(yaml.safe_dump(data['rule']))
-    print_json(data=data)
+
+    if sigma_only:
+        print(yaml.safe_dump(data['rule']))
+    else:
+        print_json(data=data)
 
 
 @detect.command('download')


### PR DESCRIPTION
small nicety:
```
(venv) mahinakaholokula@Mahinas-MacBook-Pro-2 my-prelude % prelude --profile personal detect detection b637e606-53fe-4ee7-80b4-64e494e632a8 -s                               
author: Prelude
date: '2024-01-18'
description: Detects suspicious use of cmd.exe or powershell.exe with commands often
  used for reconnaissance like directory listing, tree viewing, or searching for sensitive
  files.
detection:
  condition: selection
  selection:
    CommandLine:
    - mahina
    ParentImage:
    - .*\s+Hi\\\\cmd.exe
falsepositives:
- Legitimate administrative activities
level: medium
logsource:
  category: process_creation
  product: linux
references:
- https://attack.mitre.org/techniques/T1083/
- https://attack.mitre.org/techniques/T1087/
status: experimental
tags:
- attack.discovery
- attack.t1083
- attack.t1087
title: Suspicious Command Line Usage in Windows
```