### PR TITLE
DET-1602: dash compatibility

### DIFF
--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -27,7 +27,7 @@ do
           sleep 1
           elapsed_time=$((elapsed_time + 1))
         done
-        if [[ $code -ne 102 ]]; then
+        if [ $code -ne 102 ]; then
           wait $test_pid
           code=$?
         fi


### PR DESCRIPTION
`[[` is a bashism, and ubuntu defaults to dash. 

Debian has a "checkbashism" script, that you can install via brew, which would have called this out. 

```
checkbashisms libraries/shell/probe/nocturnal.sh 
possible bashism in libraries/shell/probe/nocturnal.sh line 28 (alternative test command ([[ foo ]] should be [ foo ])):
        if [[ $code -ne 102 ]]; then
```