### PR TITLE
DET-1602: Update if statement

### DIFF
--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -2,7 +2,7 @@
 
 ca=${PRELUDE_CA:-prelude-account-us1-us-east-2.s3.amazonaws.com}
 vst=${PRELUDE_DIR:-.vst}
-version='2.3'
+version='2.4'
 
 echo "Prelude probe: version ${version}"
 

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -27,7 +27,7 @@ do
           sleep 1
           elapsed_time=$((elapsed_time + 1))
         done
-        if [ $code -ne 102 ]; then
+        if [ "$code" != "102" ]; then
           wait $test_pid
           code=$?
         fi

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -43,7 +43,7 @@ function FromEnv { param ([string]$envVar, [string]$default)
 $ca = FromEnv "PRELUDE_CA" "prelude-account-us1-us-east-2.s3.amazonaws.com"
 $dir = FromEnv "PRELUDE_DIR" ".vst"
 $dat = ""
-$version = "2.3"
+$version = "2.4"
 
 Write-Output "Prelude probe: version ${version}"
 


### PR DESCRIPTION
My fix was incomplete. $code can resolve to nothing, which will never work with a -ne in test. Wrapping it in quotes and comparing with a string comparison seems like a suitable change. 

```
root@i-021078d13f7ac91d8:~# if [ $code -ne 102 ]; then echo no; fi
-bash: [: -ne: unary operator expected
root@i-021078d13f7ac91d8:~# if [ "$code" -ne 102 ]; then echo no; fi
-bash: [: : integer expression expected
root@i-021078d13f7ac91d8:~# if [ "$code" -ne "102" ]; then echo no; fi
-bash: [: : integer expression expected
root@i-021078d13f7ac91d8:~# if [ "$code" != "102" ]; then echo no; fi
no
root@i-021078d13f7ac91d8:~# if [ "102" != "102" ]; then echo no; fi
```