### PR TITLE
DET-1638: Update endpoint.go

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -22,7 +22,6 @@ const (
 	UnexpectedTestError      int = 1
 	TimeoutExceeded          int = 102
 	CleanupFailed            int = 103
-	OutOfMemory              int = 137
 	UnexpectedExecutionError int = 256
 
 	// Not Relevant
@@ -32,13 +31,12 @@ const (
 	TestCompletedNormally       int = 100
 	FileQuarantinedOnExtraction int = 105
 	NetworkConnectionBlocked    int = 106
-	HostNotVulnerabile          int = 107
+	HostNotVulnerable           int = 107
 	ExecutionPrevented          int = 126
 	FileQuarantinedOnExecution  int = 127
 
 	// Unprotected
 	Unprotected            int = 101
-	TestIncorrectlyBlocked int = 110
 )
 
 type fn func()


### PR DESCRIPTION
In this PR:
- Pruned a couple of exit codes that we don't use from the endpoint library
-- OutOfMemory (137) - not used, use cases uncertain/absent
-- TestIncorrectlyBlocked (110) - not used, use cases absent
- Also corrected spelling of 'HostNotVulnerabile', will submit separate PR in tests repo to correct any VSTs which emit this code