### PR TITLE
DET-1657: Add intel_context to tests

### DIFF
--- a/javascript/sdk/lib/controllers/build.ts
+++ b/javascript/sdk/lib/controllers/build.ts
@@ -1,15 +1,16 @@
 import Client from "../client";
-import type {
-  AttachedTest,
-  CreateDetectionRule,
-  CreateTestProps,
-  CreateThreatProps,
-  RequestOptions,
-  StatusResponse,
-  Threat,
-  UpdateThreatProps,
-  UploadProps,
-  UploadedAttachment,
+import {
+    AttachedTest,
+    CreateDetectionRule,
+    CreateTestProps,
+    CreateThreatProps,
+    RequestOptions,
+    StatusResponse,
+    Threat,
+    UpdateTestProps,
+    UpdateThreatProps,
+    UploadProps,
+    UploadedAttachment,
 } from "../types";
 
 export default class BuildController {
@@ -41,17 +42,14 @@ export default class BuildController {
 
   /** Update a test */
   async updateTest(
-    testId: string,
-    name?: string,
-    unit?: string,
-    technique?: string,
+    { intel_context, name, technique, testId, unit }: UpdateTestProps,
     options: RequestOptions = {},
   ): Promise<AttachedTest> {
     const response = await this.#client.requestWithAuth(
       `/build/tests/${testId}`,
       {
         method: "POST",
-        body: JSON.stringify({ name, unit, technique }),
+        body: JSON.stringify({ intel_context, name, technique, unit }),
         ...options,
       },
     );

--- a/javascript/sdk/lib/types.ts
+++ b/javascript/sdk/lib/types.ts
@@ -53,22 +53,32 @@ export interface Threat {
 }
 
 export interface CreateTestProps {
+  ai_generated?: boolean;
+  intel_context?: string;
   name: string;
-  unit: string;
   technique?: string;
   testId?: string;
-  ai_generated?: boolean;
+  unit: string;
+}
+
+export interface UpdateTestProps {
+  intel_context?: string;
+  name?: string,
+  technique?: string,
+  testId: string,
+  unit?: string,
 }
 
 export interface Test {
-  author: string | null;
   account_id: string;
+  author: string | null;
+  created: string;
   id: string;
+  intel_context?: string;
   name: string;
-  unit: string;
   technique: string | null;
   tombstoned: string | null;
-  created: string;
+  unit: string;
 }
 
 export type AttachedTest = Test & {


### PR DESCRIPTION
* Add intel_context to createTestProps
* create updateTestProps
* add intel_context to Test interface

Corresponding Python SDK changes to follow after https://github.com/preludeorg/libraries/pull/1040