### PR TITLE
Endpoint Library IPC Functionality

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -153,6 +153,15 @@ func generateKey() ([]byte, error) {
 	return key, nil
 }
 
+func GetTestIdFromExecutableName() string {
+	switch platform := GetOS(); platform {
+	case "windows":
+		return strings.Split(filepath.Base(os.Args[0]), ".")[0]
+	default:
+		return filepath.Base(os.Args[0])
+	}
+}
+
 func GetOS() string {
 	os := runtime.GOOS
 
@@ -257,9 +266,9 @@ func startDropperChildProcess() (*os.Process, error) {
 
 	switch platform := GetOS(); platform {
 	case "windows":
-		listenerPath = filepath.Join(execDir, "prelude_dropper.exe")
+		listenerPath = filepath.Join(execDir, fmt.Sprintf("%s_prelude_dropper.exe", GetTestIdFromExecutableName()))
 	default:
-		listenerPath = filepath.Join(execDir, "prelude_dropper")
+		listenerPath = filepath.Join(execDir, fmt.Sprintf("%s_prelude_dropper", GetTestIdFromExecutableName()))
 	}
 	Say("Launching " + listenerPath)
 
@@ -333,8 +342,10 @@ func Wait(dur time.Duration) {
 func Write(filename string, contents []byte) error {
 	var err error
 	if socketPath != "" {
+		Say("Performing IPC-style file write")
 		err = writeIPC(filename, contents)
 	} else {
+		Say("Performing normal file write")
 		err = os.WriteFile(Pwd(filename), contents, 0644)
 	}
 	if err != nil {

--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -197,7 +197,7 @@ func Quarantined(filename string, contents []byte) bool {
 		Say(fmt.Sprintf("Got error \"%v\" when writing file", err))
 	}
 	Wait(-1)
-	if exists := Exists(filename); exists {
+	if exists := Exists(Pwd(filename)); exists {
 		return false // file exists so return not-quarantined
 	}
 	return true // file does not exist so return yes quarantined
@@ -341,12 +341,13 @@ func Wait(dur time.Duration) {
 
 func Write(filename string, contents []byte) error {
 	var err error
+	path := Pwd(filename)
 	if socketPath != "" {
 		Say("Performing IPC-style file write")
-		err = writeIPC(filename, contents)
+		err = writeIPC(path, contents)
 	} else {
 		Say("Performing normal file write")
-		err = os.WriteFile(Pwd(filename), contents, 0644)
+		err = os.WriteFile(path, contents, 0644)
 	}
 	if err != nil {
 		return err

--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -173,18 +173,6 @@ func IsAvailable(programs ...string) bool {
 	return false
 }
 
-func IsSecure() bool {
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	} else if runtime.GOOS == "ios" {
-		return true
-	} else if runtime.GOOS == "android" {
-		return true
-	}
-	Say("Endpoint is not secure by design")
-	return false
-}
-
 func Pwd(filename string) string {
 	bin, err := os.Executable()
 	if err != nil {

--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -216,7 +216,7 @@ func Remove(path string) bool {
 	return e == nil
 }
 
-func Say(print string, ifc ... intferface{}) {
+func Say(print string, ifc ... interface{}) {
 	filename := filepath.Base(os.Args[0])
 	name := strings.TrimSuffix(filename, filepath.Ext(filename))
 	timeStamp := time.Now().Format("2006-01-02T15:04:05")

--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -220,7 +220,7 @@ func Say(print string, ifc ... intferface{}) {
 	filename := filepath.Base(os.Args[0])
 	name := strings.TrimSuffix(filename, filepath.Ext(filename))
 	timeStamp := time.Now().Format("2006-01-02T15:04:05")
-	fmt.Printf("[%s][%s] %v\n", timeStamp, name, print)
+	fmt.Printf("[%s][%s] %v\n", timeStamp, name, fmt.Sprintf(print, ifc...))
 }
 
 func SetSocketPath() {

--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -216,7 +216,7 @@ func Remove(path string) bool {
 	return e == nil
 }
 
-func Say(print string) {
+func Say(print string, ifc ... intferface{}) {
 	filename := filepath.Base(os.Args[0])
 	name := strings.TrimSuffix(filename, filepath.Ext(filename))
 	timeStamp := time.Now().Format("2006-01-02T15:04:05")


### PR DESCRIPTION
In this PR:
- we implement a dropper execution flow to be used in conjunction with VSTs which write malicious files to disk at time-of-test. this dropper is employed as a sacrificial child process of the vst process. it is implemented because we observed AV/EDR interdicting at time-of-test on those tests which write to the FS by killing the vst process, which would short-circuit the vst's code path, preventing them from emitting the proper exit code -- for example, instead of exiting PROTECTED::FileQuarantinedOnExtraction (int 127), we would instead see exit codes like (int -1). the execution model we adopt with this dropper program is such that the AV/EDR interdiction will target the dropper and not the vst process, allowing for the vst to emit the proper exit code and thus preserve test result value for the customer base.

- the dropper operates by opening a file socket on the host in the testing directory. the vst and the dropper communicate via this socket. the dropper "listens" on the file socket, and then writes gob-encoded data it receives through the socket to the victim file system.
-- adopting this model, execution flow for relevant tests will look like this:
1) VSTs now embed dropper program (not all of them, just the ones that do this)
2) VST writes embedded dropper executable to disk
3) VST starts the dropper as a child of itself
4) dropper removes any instances of the prelude socket file ("prelude_socket") from testing directory
5) dropper writes new socket file to testing directory and starts to "listen" on it
6) VST connects to the file socket
7) VST gob-encodes its payload (the malicious file) and sends it over the file socket (writes to socket file)
8) dropper receives gob-encoded payload, reads it in, decodes it, and writes the malicious file to the path specified in the gob
9) VST process does the rest of the test as they currently are encoded from here

- implemented DropperPayload data structure
-- this struct has two members: filename(str) and contents([]byte). these are set by the VST process at time-of-test.

- implemented socketPath global variable in endpoint library. this is used both to specify the path to the file socket, as well as a bat signal by Endpoint::Write() to know whether or not the dropper execution model will be employed
-- socketPath is an encapsulated (private, non-static) variable not exported by the endpoint library for safety & stability purposes
-- to set/clear, we implement mutator functions SetSocketPath() and ClearSocketPath()
-- we don't implement an accessor for the socketPath field because we want that to be invariant (always "prelude_socket").

- implemented writeIPC() function into the endpoint library
-- this function is responsible for carrying out writes to the socket. it is invoked by Write() when Endpoint.SocketPath is not emptystring.
-- writeIPC() is a private library function which: starts the dropper child process, connects to the file socket, encodes the payload, writes to the socket, and then performs a failsafe dropper process kill.

- implemented startDropperChildProcess() as a private library function which: switches on host platform to build the command line string used to invoke the dropper program; this varies based on whether or not the host OS is windows. it returns a golang process object and an error (hProc and nil upon success).
-- startDropperChildProcess() is invoked by writeIPC() at the top of the function; if we can't start the dropper then we can't do IPC-enabled file writing

- Write() and writeIPC() now return errors. when consumed, these errors provide valuable insight into why a write op failed. Quarantined() consumes these errors.

- Endpoint::Quarantined() now uses Endpoint.Exists() to perform its file check

- alphabetized function name order in the endpoint library :')