### PR TITLE
Use crypto/rand instead of math/rand for generating keys

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	crypto_rand "crypto/rand"
 	"fmt"
 	"io"
 	"io/fs"
@@ -279,8 +280,9 @@ func AES256GCMDecrypt(data, key []byte) ([]byte, error) {
 
 func generateKey() ([]byte, error) {
 	key := make([]byte, 32)
-	for i := range key {
-		key[i] = byte(rand.Intn(256))
+	_, err := crypto_rand.Read(key)
+	if err != nil {
+		return nil, err
 	}
 	return key, nil
 }


### PR DESCRIPTION
Use cryptographically secure RNG for generating XOR/AES keys rather than math/rand, which is not meant for secure applications

Example:
```golang
for i := 0; i < 10; i++ {
    key, _ := generateKey()
    fmt.Printf("key:\t %v \n", []byte(key))
}

key:     [167 200 238 129 85 20 124 90 14 235 248 59 165 160 230 41 106 61 108 2 57 162 28 38 87 17 219 193 123 215 141 190]
key:     [212 106 58 129 51 125 250 6 74 163 91 183 29 197 87 141 154 186 82 236 129 247 104 225 117 11 109 119 71 21 59 166]
key:     [233 67 254 187 137 53 237 172 92 145 51 198 91 106 174 144 66 118 79 221 131 219 169 217 75 12 206 145 166 179 185 63]
key:     [31 96 212 10 89 191 186 187 247 187 113 102 48 158 73 154 213 10 68 34 58 73 138 164 64 92 126 155 206 201 187 180]
key:     [181 224 28 208 155 250 228 181 124 112 196 34 149 105 243 81 116 246 36 146 161 36 158 168 0 204 191 7 145 106 115 10]
key:     [95 52 100 42 189 90 165 27 73 217 226 152 205 38 133 187 139 244 134 205 103 183 64 142 242 34 243 53 90 37 17 176]
key:     [217 47 185 117 6 2 254 107 33 122 243 39 250 84 226 76 140 206 154 198 253 191 164 14 149 80 1 147 122 98 19 165]
key:     [43 182 189 115 111 205 42 101 175 90 253 102 143 206 215 214 68 89 133 92 161 119 77 51 120 34 113 241 33 207 138 214]
key:     [170 65 195 222 137 142 76 117 1 149 231 150 249 142 162 47 223 12 188 85 25 26 78 49 211 174 80 62 244 83 182 209]
key:     [243 190 80 230 81 195 245 51 31 133 5 75 248 213 142 112 189 244 253 190 54 209 140 18 147 90 133 148 60 87 62 92]
```