### PR TITLE
Added embeddable dropper module sources

### DIFF
--- a/go/tests/dropper/dropper_darwin.go
+++ b/go/tests/dropper/dropper_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+// +build darwin
+
+package Dropper
+
+import (
+	_ "embed"
+)
+
+//go:embed darwin
+var Dropper []byte

--- a/go/tests/dropper/dropper_linux.go
+++ b/go/tests/dropper/dropper_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+// +build linux
+
+package Dropper
+
+import (
+	_ "embed"
+)
+
+//go:embed linux
+var Dropper []byte

--- a/go/tests/dropper/dropper_windows.go
+++ b/go/tests/dropper/dropper_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+package Dropper
+
+import (
+	_ "embed"
+)
+
+//go:embed windows
+var Dropper []byte

--- a/go/tests/dropper/go.mod
+++ b/go/tests/dropper/go.mod
@@ -1,0 +1,3 @@
+module github.com/preludeorg/libraries/go/tests/dropper
+
+go 1.21


### PR DESCRIPTION
In this PR:
- we implement a new module, `Dropper`
-- this module demonstrates a flexible, multi-platform approach to embedding a file dropper (to be used with the Endpoint package's `Dropper()` function)
-- to use in a test, the test must import this module. then, the byte slice `Dropper.Dropper` represents the executable binary's bytes that are written to the testing directory at time-of-test for file socket IPC payload handling

an example of implementing this in a VST follows:
```
...
import (
	Dropper "github.com/preludeorg/libraries/go/tests/dropper"
	Endpoint "github.com/preludeorg/libraries/go/tests/endpoint"
)
...
func test() {
	if err := Endpoint.Dropper(Dropper.Dropper); err != nil {
		Endpoint.Say("%v", err)
		Endpoint.Stop(Endpoint.UnexpectedTestError)
	}
... proceed with the rest of the test, using the written file as needed ...
```
