### PR TITLE
add Undelete and ListTechnique APIs to CLI

### DIFF
--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -99,6 +99,16 @@ def delete_test(controller, test, purge):
         data = controller.delete_test(test_id=test, purge=purge)
     print_json(data=data)
 
+@build.command('undelete-test')
+@click.argument('test')
+@click.pass_obj
+@handle_api_error
+def undelete_test(controller, test):
+    """ Undelete a test """
+    with Spinner(description='Restoring test'):
+        data = controller.undelete_test(test_id=test)
+    print_json(data=data)
+
 
 @build.command('upload')
 @click.argument('path', type=click.Path(exists=True))
@@ -232,6 +242,16 @@ def delete_threat(controller, threat, purge):
     """ Delete a threat """
     with Spinner(description='Removing threat'):
         data = controller.delete_threat(threat_id=threat, purge=purge)
+    print_json(data=data)
+
+@build.command('undelete-threat')
+@click.argument('threat')
+@click.pass_obj
+@handle_api_error
+def undelete_threat(controller, threat):
+    """ Undelete a threat """
+    with Spinner(description='Restoring threat'):
+        data = controller.undelete_threat(threat_id=threat)
     print_json(data=data)
 
 

--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -74,11 +74,21 @@ def get_test(controller, test_id):
     print_json(data=data)
 
 
+@detect.command('techniques')
+@click.pass_obj
+@handle_api_error
+def list_techniquess(controller):
+    """ List techniques """
+    with Spinner(description='Fetching techniques'):
+        data = controller.list_techniques()
+    print_json(data=data)
+
+
 @detect.command('threats')
 @click.pass_obj
 @handle_api_error
 def list_threats(controller):
-    """ List all Prelude threats """
+    """ List all threats """
     with Spinner(description='Fetching threats'):
         data = controller.list_threats()
     print_json(data=data)

--- a/python/sdk/prelude_sdk/controllers/build_controller.py
+++ b/python/sdk/prelude_sdk/controllers/build_controller.py
@@ -66,6 +66,18 @@ class BuildController(HttpController):
         raise Exception(res.text)
 
     @verify_credentials
+    def undelete_test(self, test_id):
+        """ Undelete a tombstoned test """
+        res = self._session.post(
+            f'{self.account.hq}/build/tests/{test_id}/undelete',
+            headers=self.account.headers,
+            timeout=10
+        )
+        if res.status_code == 200:
+            return res.json()
+        raise Exception(res.text)
+
+    @verify_credentials
     def upload(self, test_id, filename, data):
         """ Upload a test or attachment """
         if len(data) > 1000000:
@@ -147,6 +159,18 @@ class BuildController(HttpController):
         res = self._session.delete(
             f'{self.account.hq}/build/threats/{threat_id}',
             json=dict(purge=purge),
+            headers=self.account.headers,
+            timeout=10
+        )
+        if res.status_code == 200:
+            return res.json()
+        raise Exception(res.text)
+
+    @verify_credentials
+    def undelete_threat(self, threat_id):
+        """ Undelete a tombstoned threat """
+        res = self._session.post(
+            f'{self.account.hq}/build/threats/{threat_id}/undelete',
             headers=self.account.headers,
             timeout=10
         )

--- a/python/sdk/prelude_sdk/controllers/detect_controller.py
+++ b/python/sdk/prelude_sdk/controllers/detect_controller.py
@@ -128,6 +128,18 @@ class DetectController(HttpController):
         raise Exception(res.text)
 
     @verify_credentials
+    def list_techniques(self):
+        """ List techniques """
+        res = self._session.get(
+            f'{self.account.hq}/detect/techniques',
+            headers=self.account.headers,
+            timeout=10
+        )
+        if res.status_code == 200:
+            return res.json()
+        raise Exception(res.text)
+
+    @verify_credentials
     def list_threats(self):
         """ List threats """
         res = self._session.get(


### PR DESCRIPTION
```
(venv) mahinakaholokula@Mahinas-MacBook-Pro-2 libraries % prelude build undelete-threat e523ddac-825a-4f62-9ad5-303521bdb638
Threat could not be undeleted. Check that the tests it contains are not tombstoned.
(venv) mahinakaholokula@Mahinas-MacBook-Pro-2 libraries % prelude build undelete-test 550f9bfd-d077-48dc-8ed1-cecff5afcbc7  
{
  "status": true
}
(venv) mahinakaholokula@Mahinas-MacBook-Pro-2 libraries % prelude build undelete-threat e523ddac-825a-4f62-9ad5-303521bdb638
{
  "status": true
}


(venv) mahinakaholokula@Mahinas-MacBook-Pro-2 libraries % prelude detect techniques
...
  {
    "id": "T1659",
    "name": "Content Injection",
    "description": "Adversaries may gain access and continuously communicate with victims by injecting malicious content into systems through online network traffic. Rather than luring victims to malicious payloads hosted on a compromised website (i.e., [Drive-by Target](https://attack.mitre.org/techniques/T1608/004) followed by [Drive-by Compromise](https://attack.mitre.org/techniques/T1189)), adversaries may initially access victims through compromised data-transfer channels where they can manipulate traffic and/or inject their own content. These compromised online network channels may also be used to deliver additional payloads (i.e., [Ingress Tool Transfer](https://attack.mitre.org/techniques/T1105)) and other data to already compromised systems.(Citation: ESET MoustachedBouncer)\n\nAdversaries may inject content to victim systems in various ways, including:\n\n* From the middle, where the adversary is in-between legitimate online client-server communications (**Note:** this is similar but distinct from [Adversary-in-the-Middle](https://attack.mitre.org/techniques/T1557), which describes AiTM activity solely within an enterprise environment) (Citation: Kaspersky Encyclopedia MiTM)\n* From the side, where malicious content is injected and races to the client as a fake response to requests of a legitimate online server (Citation: Kaspersky ManOnTheSide)\n\nContent injection is often the result of compromised upstream communication channels, for example at the level of an internet service provider (ISP) as is the case with \"lawful interception.\"(Citation: Kaspersky ManOnTheSide)(Citation: ESET MoustachedBouncer)(Citation: EFF China GitHub Attack)",
    "crwd_expected": "OBSERVE"
  },
  {
    "id": "T1665",
    "name": "Hide Infrastructure",
    "description": "Adversaries may manipulate network traffic in order to hide and evade detection of their C2 infrastructure. This can be accomplished in various ways including by identifying and filtering traffic from defensive tools,(Citation: TA571) masking malicious domains to obfuscate the true destination from both automated scanning tools and security researchers,(Citation: Schema-abuse)(Citation: Facad1ng)(Citation: Browser-updates) and otherwise hiding malicious artifacts to delay discovery and prolong the effectiveness of adversary infrastructure that could otherwise be identified, blocked, or taken down entirely.\n\nC2 networks may include the use of [Proxy](https://attack.mitre.org/techniques/T1090) or VPNs to disguise IP addresses, which can allow adversaries to blend in with normal network traffic and bypass conditional access policies or anti-abuse protections. For example, an adversary may use a virtual private cloud to spoof their IP address to closer align with a victim's IP address ranges. This may also bypass security measures relying on geolocation of the source IP address.(Citation: sysdig)(Citation: Orange Residential Proxies)\n\nAdversaries may also attempt to filter network traffic in order to evade defensive tools in numerous ways, including blocking/redirecting common incident responder or security appliance user agents.(Citation: mod_rewrite)(Citation: SocGholish-update) Filtering traffic based on IP and geo-fencing may also avoid automated sandboxing or researcher activity (i.e., [Virtualization/Sandbox Evasion](https://attack.mitre.org/techniques/T1497)).(Citation: TA571)(Citation: mod_rewrite)\n\nHiding C2 infrastructure may also be supported by [Resource Development](https://attack.mitre.org/tactics/TA0042) activities such as [Acquire Infrastructure](https://attack.mitre.org/techniques/T1583) and [Compromise Infrastructure](https://attack.mitre.org/techniques/T1584). For example, using widely trusted hosting services or domains such as prominent URL shortening providers or marketing services for C2 networks may enable adversaries to present benign content that later redirects victims to malicious web pages or infrastructure once specific conditions are met.(Citation: StarBlizzard)(Citation: QR-cofense)",
    "crwd_expected": "OBSERVE"
  }
]
```