### PR TITLE
DET-1220: fix invalid-publisher #1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   release-build:
     runs-on: ubuntu-latest
     outputs:
-      out: ${{ steps.buildreleasedist.outputs.semver }}
+      semver: ${{ steps.buildreleasedist.outputs.semver }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -28,7 +28,7 @@ jobs:
           python -m build
           setup_semver=$(grep version setup.cfg | cut -d' ' -f3)
 
-          echo "semver=$setup_semver" >> $GITHUB_OUTPUT
+          echo "semver=$setup_semver" >> "$GITHUB_OUTPUT"
       - name: upload release dist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,7 @@ jobs:
           name: release-dist
           path: ./python/${{ inputs.package }}/dist/
   pypi-publish:
-    environment:
-      name: pypi
-      url: https://pypi.org/p/${{ inputs.package  }}
+    environment: release
     runs-on: ubuntu-latest
     needs:
       - release-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           name: release-dist
           path: ./python/${{ inputs.package }}/dist/
   pypi-publish:
+    environment:
+      name: pypi
+      url: https://pypi.org/p/${{ inputs.package  }}
     runs-on: ubuntu-latest
     needs:
       - release-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,22 @@ on:
 jobs:
   release-build:
     runs-on: ubuntu-latest
+    outputs:
+      out: ${{ steps.buildreleasedist.outputs.semver }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: build release dist
+        id: buildreleasedist
         working-directory: ./python/${{ inputs.package }}
         run: |
           python -m pip install -U build
           python -m build
+          setup_semver=$(grep version setup.cfg | cut -d' ' -f3)
+
+          echo "semver=$setup_semver" >> $GITHUB_OUTPUT
       - name: upload release dist
         uses: actions/upload-artifact@v4
         with:
@@ -34,6 +40,7 @@ jobs:
     needs:
       - release-build
     permissions:
+      contents: write
       id-token: write
     steps:
       - name: download release dist
@@ -43,6 +50,15 @@ jobs:
           path: dist/
       - name: publish release dist to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+      - name: tag repo
+        if: success()
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          
+          tag="python/${{ inputs.package }}/${{ needs.release-build.outputs.semver }}"
+          git tag $tag
+          git push origin $tag
       - name: Notify Slack
         if: always()
         uses: slackapi/slack-github-action@v1.26.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Python CLI and SDK
+name: Release Python CLI or SDK
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Took a couple commits, but we got there. 
This run fails: https://github.com/preludeorg/libraries/actions/runs/10746017831/job/29806176774 but it's because we've already shipped the 2.0 sdk to pypi. With an appropriate semver, it would have gone thru. 

I can't test it until the first real run, but I'm pretty sure this will also tag the repo right. 

