### PR TITLE
fix up py sdk tests

### DIFF
--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -81,7 +81,7 @@ def update_test(controller, test, crowdstrike_expected, name, unit, technique):
     with Spinner(description='Updating test'):
         data = controller.update_test(
             test_id=test,
-            crowdstrike_expected_outcome=EDRResponse[crowdstrike_expected],
+            crowdstrike_expected_outcome=EDRResponse[crowdstrike_expected]if crowdstrike_expected else None,
             name=name,
             unit=unit,
             technique=technique

--- a/python/sdk/tests/conftest.py
+++ b/python/sdk/tests/conftest.py
@@ -165,6 +165,6 @@ def setup_threat_hunt(unwrap):
         build,
         control=Control.CROWDSTRIKE,
         name='test threat hunt',
-        query='test query',
+        query='#repo=base_sensor | ImageFileName is not null | ParentBaseFileName is not null',
         test_id=pytest.test_id,
         threat_hunt_id=pytest.threat_hunt_id)

--- a/python/sdk/tests/conftest.py
+++ b/python/sdk/tests/conftest.py
@@ -156,15 +156,24 @@ def setup_detection(unwrap):
 def setup_threat_hunt(unwrap):
     if not pytest.expected_account['features']['threat_intel']:
         return
-    if hasattr(pytest, 'expected_threat_hunt'):
+    if hasattr(pytest, 'crwd_threat_hunt_id') and hasattr(pytest, 'mde_threat_hunt_id'):
         return
 
     build = BuildController(pytest.account)
-    pytest.threat_hunt_id = str(uuid.uuid4())
+    pytest.crwd_threat_hunt_id = str(uuid.uuid4())
     pytest.expected_threat_hunt = unwrap(build.create_threat_hunt)(
         build,
         control=Control.CROWDSTRIKE,
-        name='test threat hunt',
+        name='test CRWD threat hunt',
         query='#repo=base_sensor | ImageFileName is not null | ParentBaseFileName is not null',
         test_id=pytest.test_id,
-        threat_hunt_id=pytest.threat_hunt_id)
+        threat_hunt_id=pytest.crwd_threat_hunt_id)
+
+    pytest.mde_threat_hunt_id = str(uuid.uuid4())
+    unwrap(build.create_threat_hunt)(
+        build,
+        control=Control.DEFENDER,
+        name='test MDE threat hunt',
+        query='DeviceProcessEvents | where isnotempty(FileName) and isnotempty(InitiatingProcessFolderPath) and isnotempty(DeviceId) | take 5',
+        test_id=pytest.test_id,
+        threat_hunt_id=pytest.mde_threat_hunt_id)

--- a/python/sdk/tests/test_build.py
+++ b/python/sdk/tests/test_build.py
@@ -43,7 +43,7 @@ class TestVST:
 
     def test_upload(self, unwrap):
         def wait_for_compile(job_id):
-            timeout = time.time() + 60
+            timeout = time.time() + 120
             while time.time() < timeout:
                 time.sleep(5)
                 res = unwrap(self.build.get_compile_status)(self.build, job_id=job_id)
@@ -308,7 +308,7 @@ class TestThreatHunt:
             control=Control.CROWDSTRIKE.value,
             id=pytest.threat_hunt_id,
             name='test threat hunt',
-            query='test query',
+            query='#repo=base_sensor | ImageFileName is not null | ParentBaseFileName is not null',
             test_id=pytest.test_id,
         )
 
@@ -335,10 +335,10 @@ class TestThreatHunt:
         pytest.expected_threat_hunt = unwrap(self.build.update_threat_hunt)(
             self.build,
             name='updated threat hunt',
-            query='.*',
+            query='#repo=base_sensor | ImageFileName is not null | ParentBaseFileName is not null | aid is not null',
             threat_hunt_id=pytest.threat_hunt_id)
         assert pytest.expected_threat_hunt['name'] == 'updated threat hunt'
-        assert pytest.expected_threat_hunt['query'] == '.*'
+        assert pytest.expected_threat_hunt['query'] == '#repo=base_sensor | ImageFileName is not null | ParentBaseFileName is not null | aid is not null'
 
     @pytest.mark.order(-4)
     def test_delete_threat_hunt(self, unwrap):

--- a/python/sdk/tests/test_build.py
+++ b/python/sdk/tests/test_build.py
@@ -306,8 +306,8 @@ class TestThreatHunt:
         expected = dict(
             account_id=pytest.account.headers['account'],
             control=Control.CROWDSTRIKE.value,
-            id=pytest.threat_hunt_id,
-            name='test threat hunt',
+            id=pytest.crwd_threat_hunt_id,
+            name='test CRWD threat hunt',
             query='#repo=base_sensor | ImageFileName is not null | ParentBaseFileName is not null',
             test_id=pytest.test_id,
         )
@@ -316,7 +316,7 @@ class TestThreatHunt:
         assert not diffs, json.dumps(diffs, indent=2)
 
     def test_get_threat_hunt(self, unwrap):
-        res = unwrap(self.detect.get_threat_hunt)(self.detect, threat_hunt_id=pytest.threat_hunt_id)
+        res = unwrap(self.detect.get_threat_hunt)(self.detect, threat_hunt_id=pytest.crwd_threat_hunt_id)
 
         diffs = check_dict_items(pytest.expected_threat_hunt, res)
         assert not diffs, json.dumps(diffs, indent=2)
@@ -336,12 +336,12 @@ class TestThreatHunt:
             self.build,
             name='updated threat hunt',
             query='#repo=base_sensor | ImageFileName is not null | ParentBaseFileName is not null | aid is not null',
-            threat_hunt_id=pytest.threat_hunt_id)
+            threat_hunt_id=pytest.crwd_threat_hunt_id)
         assert pytest.expected_threat_hunt['name'] == 'updated threat hunt'
         assert pytest.expected_threat_hunt['query'] == '#repo=base_sensor | ImageFileName is not null | ParentBaseFileName is not null | aid is not null'
 
     @pytest.mark.order(-4)
     def test_delete_threat_hunt(self, unwrap):
-        unwrap(self.build.delete_threat_hunt)(self.build, threat_hunt_id=pytest.threat_hunt_id)
+        unwrap(self.build.delete_threat_hunt)(self.build, threat_hunt_id=pytest.crwd_threat_hunt_id)
         with pytest.raises(Exception):
-            unwrap(self.detect.get_threat_hunt)(self.detect, threat_hunt_id=pytest.threat_hunt_id)
+            unwrap(self.detect.get_threat_hunt)(self.detect, threat_hunt_id=pytest.crwd_threat_hunt_id)

--- a/python/sdk/tests/test_detect.py
+++ b/python/sdk/tests/test_detect.py
@@ -27,7 +27,7 @@ class TestDetect:
     def test_list_techniques(self, unwrap):
         res = unwrap(self.detect.list_techniques)(self.detect)
         assert 1 <= len(res)
-        assert {'id', 'name', 'description', 'expected'} == set(res[0].keys())
+        assert {'category', 'description', 'expected', 'id', 'name'} == set(res[0].keys())
 
     def test_register_endpoint(self, unwrap):
         res = unwrap(self.detect.register_endpoint)(self.detect, host=self.host, serial_num=self.serial, tags=self.tags)


### PR DESCRIPTION
* update API responses
* add new tests (Defender ODP)
* fix small CLI bug (update-test was erroring if control wasn't being updated)

us2 run:
```
===================================================================================== short test summary info =====================================================================================
FAILED python/sdk/tests/test_partner.py::TestPartner::test_observed_detected[defender] - assert 1 <= 0
 +  where 0 = len([])
FAILED python/sdk/tests/test_generate.py::TestGenerate::test_generate_from_partner_advisory - Exception: ('Failed to get advisory %s: %s', 10241168, [{'message': 'PDF is not found.  Please validate parameter(s) in your query'}])
====================================================================== 2 failed, 94 passed, 12 skipped in 282.55s (0:04:42) =======================================================================
```

* defender odp failure i'll look into but fine for it to be returning empty for this release
* threat intel failure seems a bit of a one off (a different advisory id via UI did generate, so must be something funky with the latest one)