### PR TITLE
Fixed random 21 error when uploading subdirectories

### DIFF
--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -143,7 +143,7 @@ def upload_attachment(controller, path, test):
     if Path(path).is_file():
         upload(p=Path(path))
     else:
-        objs = list(Path(path).rglob('*'))
+        objs = list(Path(path).glob('*'))
         for ind, obj in enumerate(objs):
             try:
                 upload(p=Path(obj), skip_compile=ind != len(objs) - 1)

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -117,6 +117,9 @@ def upload_attachment(controller, path, test):
         raise FileNotFoundError('You must supply a test ID or include it in the path')
 
     def upload(p: Path, skip_compile=False):
+        if not p.is_file():
+            return
+
         with open(p, 'rb') as data:
             with Spinner(description='Uploading to test') as spinner:
                 data = controller.upload(

--- a/python/cli/prelude_cli/views/shared.py
+++ b/python/cli/prelude_cli/views/shared.py
@@ -15,7 +15,7 @@ def pretty_print(func):
                 res = [res]
             return print_json(data=dict(status='complete', results=res, message=msg))
         except Exception as e:
-            return print_json(data=dict(status='error', results=None, message=e.args[0]))
+            return print_json(data=dict(status='error', results=None, message=" ".join(str(arg) for arg in e.args)))
     return handler
 
 


### PR DESCRIPTION
The `rglob(...)` function will return files recursively, but this includes subdirectories. The `upload(...)` function will attempt to open those directories and throw an exception. Specifically `[Errno 21] Is a directory`. So I've added a check to `upload(...)` to return immediately if passed a directory. Additionally, I've modified the error message that is returned to include all of `e.args` because `e.args[0]` was `21` and `e.args[1]` was `Is a directory`, which is more useful for debugging purposes.