### PR TITLE
Det 2739: account must be in keychain

### DIFF
--- a/python/sdk/prelude_sdk/models/account.py
+++ b/python/sdk/prelude_sdk/models/account.py
@@ -93,19 +93,13 @@ class Account:
             raise ValueError(
                 "Please make sure you are using an up-to-date profile with the following fields: account, handle, hq"
             )
-        if (
-            oidc := profile_items.get("oidc")
-            and oidc == "custom"
-            and not (slug := profile_items.get("slug"))
-        ):
-            raise ValueError("Please provide a slug for custom OIDC providers")
         return _Account(
             account=profile_items["account"],
             handle=profile_items["handle"],
             hq=profile_items["hq"],
-            oidc=oidc,
+            oidc=profile_items.get("oidc"),
             profile=profile,
-            slug=slug,
+            slug=profile_items.get("slug"),
         )
 
     @staticmethod

--- a/python/sdk/prelude_sdk/models/account.py
+++ b/python/sdk/prelude_sdk/models/account.py
@@ -89,17 +89,23 @@ class Account:
         """
         keychain = Keychain()
         profile_items = keychain.get_profile(profile)
-        if "handle" not in profile_items:
+        if any([item not in profile_items for item in ["account", "handle", "hq"]]):
             raise ValueError(
                 "Please make sure you are using an up-to-date profile with the following fields: account, handle, hq"
             )
+        if (
+            oidc := profile_items.get("oidc")
+            and oidc == "custom"
+            and not (slug := profile_items.get("slug"))
+        ):
+            raise ValueError("Please provide a slug for custom OIDC providers")
         return _Account(
             account=profile_items["account"],
             handle=profile_items["handle"],
             hq=profile_items["hq"],
-            oidc=profile_items.get("oidc"),
+            oidc=oidc,
             profile=profile,
-            slug=profile_items.get("slug"),
+            slug=slug,
         )
 
     @staticmethod


### PR DESCRIPTION
- raise a better error when account/handle/hq isn't in the keychain profile
- raise an error when custom oidc doesn't have slug (this shouldn't happen unless someone messes with their configured keychain file directly)