### PR TITLE
Det 3130 enable exceptions in prelude cli

### DIFF
--- a/python/cli/prelude_cli/views/scm.py
+++ b/python/cli/prelude_cli/views/scm.py
@@ -355,6 +355,82 @@ def parse_from_partner_advisory(controller, partner, advisory_id):
             partner=Control[partner], advisory_id=advisory_id
         )
 
+@scm.command("list-policy-exceptions")
+@click.pass_obj
+@pretty_print
+def list_exceptions(controller):
+    """List exceptions"""
+    with Spinner(description=f"Querying Policy exceptions"):
+        return controller.list_policy_exceptions()
+
+@scm.command("put-policy-exception")
+@click.argument(
+    "partner",
+    type=click.Choice(
+        [c.name for c in Control if c != Control.INVALID], case_sensitive=False
+    ),
+)
+@click.option("-e", "--expires", help="Expiry Date (YYYY-MM-DD hh:mm:ss ([+-]hh:mm))", default=None, type=str)
+@click.option("-i", "--instance_id", required=True, help="instance ID of the partner")
+@click.option("-p", "--policy_id", required=True, help="instance ID of the partner")
+@click.option("s", "--settings", help="Comma separated list of setting names", default=None)
+@click.pass_obj
+@pretty_print
+def put_policy_exception(controller, partner, expires=None, instance_id=None, policy_id=None, setting_names=None ):
+    """put policy exception"""
+    with Spinner(description=f"Upserting Policy exceptions"):
+        return controller.put_policy_exception(
+            partner=partner,
+            expires=expires,
+            instance_id=instance_id, 
+            policy_id=policy_id, 
+            setting_names=setting_names.split(",") if setting_names else None
+        )
+
+
+@scm.command("list-object-exceptions")
+@click.pass_obj
+@pretty_print
+def list_exceptions(controller):
+    """List exceptions"""
+    with Spinner(description=f"Querying Object exceptions"):
+        return controller.list_object_exceptions()
+
+
+@scm.command("create-object-exception")
+@click.argument("category", type=click.Choice([c.name for c in ControlCategory], case_sensitive=False))
+@click.option("-n", "--name", help="Exception Name", default=None, type=str)
+@click.option("-f", "--filter", help="OData filter string", default=None, required=True, type=str)
+@click.option("-e", "--expires", help="Expiry Date (YYYY-MM-DD hh:mm:ss ([+-]hh:mm))", default=None, type=str)
+@click.pass_obj
+@pretty_print
+def create_object_exception(controller, category, filter=None, name=None, expires=None ):
+    """create object exception"""
+    with Spinner(description=f"Creating Object exceptions"):
+        return controller.create_object_exception(category=category, filter=filter, name=name, expires=expires)
+
+@scm.command("update-object-exception")
+@click.option("-i", "--id", help="ID of the exception to update", default=None, type=str)
+@click.option("-n", "--name", help="Exception Name", default=None, type=str)
+@click.option("-f", "--filter", help="OData filter string", default=None, required=True, type=str)
+@click.option("-e", "--expires", help="Expiry Date (YYYY-MM-DD hh:mm:ss ([+-]hh:mm))", default=None, type=str)
+@click.pass_obj
+@pretty_print
+def update_object_exception(controller, id=None, filter=None, name=None, expires=None ):
+    """update object exception"""
+    with Spinner(description=f"Updating Object exceptions"):
+        return controller.update_object_exception(exception_id=id, filter=filter, name=name, expires=expires)
+
+@scm.command("delete-object-exception")
+@click.option("-i", "--id", help="ID of the exception to update", default=None, type=str)
+@click.confirmation_option(prompt="Are you sure?")
+@click.pass_obj
+@pretty_print
+def update_object_exception(controller, id=None, filter=None, name=None, expires=None ):
+    """update object exception"""
+    with Spinner(description=f"Delete Object exception"):
+        return controller.update_object_exception(exception_id=id, filter=filter, name=name, expires=expires)
+
 
 @scm.command("list-notifications")
 @click.pass_obj

--- a/python/cli/prelude_cli/views/scm.py
+++ b/python/cli/prelude_cli/views/scm.py
@@ -373,18 +373,18 @@ def list_exceptions(controller):
 @click.option("-e", "--expires", help="Expiry Date (YYYY-MM-DD hh:mm:ss ([+-]hh:mm))", default=None, type=str)
 @click.option("-i", "--instance_id", required=True, help="instance ID of the partner")
 @click.option("-p", "--policy_id", required=True, help="instance ID of the partner")
-@click.option("s", "--settings", help="Comma separated list of setting names", default=None)
+@click.option("-s", "--settings", help="Comma separated list of setting names", default=None)
 @click.pass_obj
 @pretty_print
-def put_policy_exception(controller, partner, expires=None, instance_id=None, policy_id=None, setting_names=None ):
+def put_policy_exception(controller, partner, expires=None, instance_id=None, policy_id=None, settings=None ):
     """put policy exception"""
     with Spinner(description=f"Upserting Policy exceptions"):
-        return controller.put_policy_exception(
-            partner=partner,
+        return controller.put_policy_exceptions(
+            partner=Control[partner],
             expires=expires,
             instance_id=instance_id, 
             policy_id=policy_id, 
-            setting_names=setting_names.split(",") if setting_names else None
+            setting_names=settings.split(",") if settings else None
         )
 
 
@@ -398,7 +398,7 @@ def list_exceptions(controller):
 
 
 @scm.command("create-object-exception")
-@click.argument("category", type=click.Choice([c.name for c in ControlCategory], case_sensitive=False))
+@click.argument("category", type=click.Choice([c.name for c in ControlCategory if c not in [ControlCategory.NONE, ControlCategory.INVALID, ControlCategory.PRIVATE_REPO]], case_sensitive=False))
 @click.option("-n", "--name", help="Exception Name", default=None, type=str)
 @click.option("-f", "--filter", help="OData filter string", default=None, required=True, type=str)
 @click.option("-e", "--expires", help="Expiry Date (YYYY-MM-DD hh:mm:ss ([+-]hh:mm))", default=None, type=str)
@@ -407,7 +407,7 @@ def list_exceptions(controller):
 def create_object_exception(controller, category, filter=None, name=None, expires=None ):
     """create object exception"""
     with Spinner(description=f"Creating Object exceptions"):
-        return controller.create_object_exception(category=category, filter=filter, name=name, expires=expires)
+        return controller.create_object_exception(category=ControlCategory[category], filter=filter, name=name, expires=expires)
 
 @scm.command("update-object-exception")
 @click.option("-i", "--id", help="ID of the exception to update", default=None, type=str)


### PR DESCRIPTION
For discussion - this adds CLI capabilities to match SDK execptions.

objects follow a CRUD approach
policies have a list and a "put" function only.

We should align for consistency.... is there value in a single "list" function (where type is passed in as object, policy, all)?

It is difficult for a customer to identify the control ID/Category ID when an ID is expected in the CLI/SDK
It is difficult for a customer to know their  policy_id - Customers are going to be more familiar with their policy_name vs policy_id.
If we don't allow 2 instances to have the same name, I'd say the same is true for instance_id

It would be handy if our back end was able to use either, based on "is this a uuid or a non-uuid string" perhaps? (or we could be explicit and have 2 params).

Anyway for now, I have a PR for the way the current SDK is, so we can discuss.