### PR TITLE
det-3516: fix EMAIL_MALWARE mapping

### DIFF
--- a/python/sdk/prelude_sdk/models/codes.py
+++ b/python/sdk/prelude_sdk/models/codes.py
@@ -536,7 +536,7 @@ class PolicyType(Enum, metaclass=MissingItem):
             ],
             PolicyType.EMAIL_OUTBOUND: ControlCategory.mapping()[ControlCategory.EMAIL],
             PolicyType.EMAIL_CONTENT: ControlCategory.mapping()[ControlCategory.EMAIL],
-            PolicyType.EMAIL_MALWARE: ControlCategory.mapping()[ControlCategory.EMAIL],
+            PolicyType.EMAIL_MALWARE: [Control.M365],
             PolicyType.EMAIL_ATTACHMENT: ControlCategory.mapping()[
                 ControlCategory.EMAIL
             ],


### PR DESCRIPTION
we only have MALWARE recs for M365 right now

.. i see some pros in making this an internal mapping that we build directly from the RECOMMENDATIONS file ..