### PR TITLE
fix: test

### DIFF
--- a/python/sdk/tests/test_build.py
+++ b/python/sdk/tests/test_build.py
@@ -107,6 +107,7 @@ class TestVST:
 
     def test_get_test(self, unwrap):
         res = unwrap(self.detect.get_test)(self.detect, test_id=pytest.test_id)
+        pytest.expected_test["updated"] = res["updated"]
 
         diffs = check_dict_items(pytest.expected_test, res)
         assert not diffs, json.dumps(diffs, indent=2)

--- a/python/sdk/tests/test_partner.py
+++ b/python/sdk/tests/test_partner.py
@@ -115,12 +115,13 @@ class TestPartnerAttach:
         expected = dict(api=partner_api, connected=True)
         assert expected == res
 
-    def test_get_account(self, unwrap, control, partner_api, user, secret):
+    def test_get_account(self, unwrap, email, control, partner_api, user, secret):
         res = unwrap(self.iam.get_account)(self.iam)
         [r.pop("created") for r in res["controls"]]
         pytest.controls = {c["id"]: c["instance_id"] for c in res["controls"]}
         expected = dict(
             api=partner_api,
+            created_by=email,
             id=control.value,
             instance_id=pytest.controls[control.value],
             max_groups=30,


### PR DESCRIPTION
- controls have new created_by field
- 'updated' field in get_test needs to be updated because attaching files updates the time (which is done in the test_upload test)