### PR TITLE
update PrivilegeLabel to match renamed helper folder convention

### DIFF
--- a/go/tests/agent/agent.go
+++ b/go/tests/agent/agent.go
@@ -77,9 +77,9 @@ func VstID() string {
 	return name
 }
 
-// PrivilegeLabel derives the privilege label from the current working directory name, expecting a format like "PreludeHelper_Label".
+// PrivilegeLabel derives the privilege label from the current working directory name, expecting a format like "prelude-helper-Label".
 func PrivilegeLabel() string {
-	label, found := strings.CutPrefix(filepath.Base(cwd), "PreludeHelper_")
+	label, found := strings.CutPrefix(filepath.Base(cwd), "prelude-helper-")
 	if !found {
 		return ""
 	}


### PR DESCRIPTION
## Summary

- Updates `PrivilegeLabel()` in `go/tests/agent/agent.go` to match the renamed helper folder convention: `prelude-helper-<label>` (kebab-case) instead of `PreludeHelper_<label>` (PascalCase + underscore)

## Test plan

- [x] `TestPrivilegeLabelNoMatch` passes (no match on non-helper cwd)
- [x] `TestPrivilegeLabelMatch` passes (correctly extracts label from `prelude-helper-Admin` → `"admin"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)