### PR TITLE
det-4259: runtime timeout profiles support

### DIFF
--- a/go/tests/endpoint/endpoint.go
+++ b/go/tests/endpoint/endpoint.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"strconv"
 	"time"
 )
 
@@ -302,13 +303,20 @@ func Start(test fn, clean ...fn) {
 
 	Say(fmt.Sprintf("Starting test at: %s", time.Now().Format("2006-01-02T15:04:05")))
 
+	timeout := 60 * time.Second
+    if val := os.Getenv("PRELUDE_TIMEOUT"); val != "" {
+        if secs, err := strconv.Atoi(val); err == nil && secs > 0 {
+            timeout = time.Duration(secs) * time.Second
+        }
+    }
+
 	go func() {
 		test()
 	}()
 
 	select {
-	case <-time.After(30 * time.Second):
-		Say("Test timed out after 30 seconds")
+	case <-time.After(timeout):
+		Say("Test timed out after %v", timeout)
 		Stop(TimeoutExceeded)
 	}
 }

--- a/shell/probe/nocturnal.sh
+++ b/shell/probe/nocturnal.sh
@@ -20,10 +20,10 @@ do
         chmod +x "$vst/$uuid"
         echo "Invoking $uuid"
         cd "$vst" || exit 1
-        ./"$uuid" & test_pid=$!
+        PRELUDE_TIMEOUT=60 ./"$uuid" & test_pid=$!
         elapsed_time=0
         while kill -0 $test_pid 2> /dev/null; do
-          if [ $elapsed_time -ge 45 ]; then
+          if [ $elapsed_time -ge 75 ]; then
             disown $test_pid
             kill -9 $test_pid 2> /dev/null
             echo "TIMEOUT: Killed long running test ${uuid} (${test_pid})"

--- a/shell/probe/raindrop.ps1
+++ b/shell/probe/raindrop.ps1
@@ -6,9 +6,10 @@ function Execute {
     try {
         $stdoutTempFile = New-Item -path "$dir\stdout.log" -Force
         $stderrTempFile = New-Item -path "$dir\stderr.log" -Force
+        $env:PRELUDE_TIMEOUT = 60
         $proc = Start-Process -WorkingDirectory "$dir" -FilePath $File -NoNewWindow -PassThru -RedirectStandardOutput $stdoutTempFile -RedirectStandardError $stderrTempFile
 
-        $proc | Wait-Process -Timeout 45 -ErrorAction SilentlyContinue -ErrorVariable timeoutVar
+        $proc | Wait-Process -Timeout 75 -ErrorAction SilentlyContinue -ErrorVariable timeoutVar
 
         if ($timeoutVar) {
             $proc | kill


### PR DESCRIPTION
## Summary

supporting https://github.com/preludeorg/libraries/pull/1313 

- Adds `PRELUDE_TIMEOUT` env var support in the Go VST (`endpoint.go`) — timeout defaults to 60s, overridable via the env var
- Passes `PRELUDE_TIMEOUT=60` to VST processes from both `nocturnal.sh` and `raindrop.ps1` probes
- Bumps outer probe kill timeout from 45s → 75s in both shell probes (giving headroom above the 60s VST timeout)


## Test plan

- [ ] Verify Go VST respects `PRELUDE_TIMEOUT` and self-terminates at the configured value
- [ ] Verify probe kills the process at 75s if VST does not self-terminate


