### PR TITLE
det-4282: test fields + sync

### DIFF
--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -234,7 +234,12 @@ def update_test(
         }
         params.update(overrides)
 
-    crwd = params.get("crowdstrike_expected", crowdstrike_expected)
+    expected = params.get("expected") or {}
+    crwd = (
+        params.get("crowdstrike_expected")
+        or expected.get("crowdstrike")
+        or crowdstrike_expected
+    )
     with Spinner(description="Updating test"):
         return controller.update_test(
             attack_stage=params.get("attack_stage", attack_stage),

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -59,7 +59,7 @@ def clone_test(controller, source_test_id):
     "-s",
     "--schedulable",
     help="available to be scheduled by SCHEDULER users",
-    is_flag=True,
+    flag_value=True,
 )
 @click.option("--tags", help="tag (can be specified multiple times)", multiple=True)
 @click.option("-t", "--test", help="test identifier")
@@ -103,41 +103,47 @@ def create_test(
         with open(dir, "w", encoding="utf8") as code:
             code.write(template_body)
 
+    metadata = json.loads(metadata) if metadata else None
+    frameworks = list(frameworks) if frameworks else None
+    tags = list(tags) if tags else None
+
+    params = {}
     if config and os.path.exists(config):
         with open(config, "r") as f:
-            config_data = json.load(f)
-        name = config_data.get("name") or name
-        attack_stage = config_data.get("attack_stage") or attack_stage
-        frameworks = config_data.get("frameworks") or (
-            list(frameworks) if frameworks else None
-        )
-        impact = config_data.get("impact") or impact
-        metadata = config_data.get("metadata") or (
-            json.loads(metadata) if metadata else None
-        )
-        privilege = config_data.get("privilege") or privilege
-        schedulable = (
-            config_data.get("schedulable") if schedulable is None else schedulable
-        )
-        tags = config_data.get("tags") or (list(tags) if tags else None)
-        technique = config_data.get("technique") or technique
-        unit = config_data.get("unit") or unit
-    if not unit:
+            params = json.load(f)
+        overrides = {
+            k: v
+            for k, v in dict(
+                attack_stage=attack_stage,
+                frameworks=frameworks,
+                impact=impact,
+                metadata=metadata,
+                privilege=privilege,
+                schedulable=schedulable,
+                tags=tags,
+                technique=technique,
+                unit=unit,
+            ).items()
+            if v is not None
+        }
+        params.update(overrides)
+
+    if not params.get("unit", unit):
         raise ValueError("Unit is required to create a test")
 
     with Spinner(description="Creating new test"):
         res = controller.create_test(
             name=name,
-            attack_stage=attack_stage,
-            frameworks=frameworks,
-            impact=impact,
-            metadata=metadata,
-            privilege=privilege,
-            schedulable=schedulable,
-            tags=tags,
+            attack_stage=params.get("attack_stage", attack_stage),
+            frameworks=params.get("frameworks", frameworks),
+            impact=params.get("impact", impact),
+            metadata=params.get("metadata", metadata),
+            privilege=params.get("privilege", privilege),
+            schedulable=params.get("schedulable", schedulable),
+            tags=params.get("tags", tags),
             test_id=test,
-            technique=technique,
-            unit=unit,
+            technique=params.get("technique", technique),
+            unit=params.get("unit", unit),
         )
 
     if not test:
@@ -177,7 +183,7 @@ def create_test(
     "-s",
     "--schedulable",
     help="available to be scheduled by SCHEDULER users",
-    is_flag=True,
+    flag_value=True,
 )
 @click.option("--tags", help="tag (can be specified multiple times)", multiple=True)
 @click.option("-q", "--technique", help="MITRE ATT&CK code [e.g. T1557]")
@@ -201,45 +207,48 @@ def update_test(
     unit,
 ):
     """Update a security test"""
+    metadata = json.loads(metadata) if metadata else None
+    frameworks = list(frameworks) if frameworks else None
+    tags = list(tags) if tags else None
+
+    params = {}
     if config and os.path.exists(config):
         with open(config, "r") as f:
-            config_data = json.load(f)
-        name = config_data.get("name") or name
-        attack_stage = config_data.get("attack_stage") or attack_stage
-        crowdstrike_expected = (
-            config_data.get("crowdstrike_expected") or crowdstrike_expected
-        )
-        frameworks = config_data.get("frameworks") or (
-            list(frameworks) if frameworks else None
-        )
-        impact = config_data.get("impact") or impact
-        metadata = config_data.get("metadata") or (
-            json.loads(metadata) if metadata else None
-        )
-        privilege = config_data.get("privilege") or privilege
-        schedulable = (
-            config_data.get("schedulable") if schedulable is None else schedulable
-        )
-        tags = config_data.get("tags") or (list(tags) if tags else None)
-        technique = config_data.get("technique") or technique
-        unit = config_data.get("unit") or unit
+            params = json.load(f)
+        overrides = {
+            k: v
+            for k, v in dict(
+                attack_stage=attack_stage,
+                crowdstrike_expected=crowdstrike_expected,
+                frameworks=frameworks,
+                impact=impact,
+                metadata=metadata,
+                name=name,
+                privilege=privilege,
+                schedulable=schedulable,
+                tags=tags,
+                technique=technique,
+                unit=unit,
+            ).items()
+            if v is not None
+        }
+        params.update(overrides)
 
+    crwd = params.get("crowdstrike_expected", crowdstrike_expected)
     with Spinner(description="Updating test"):
         return controller.update_test(
-            attack_stage=attack_stage,
-            crowdstrike_expected_outcome=(
-                EDRResponse[crowdstrike_expected] if crowdstrike_expected else None
-            ),
-            frameworks=frameworks,
-            impact=impact,
-            metadata=metadata,
-            name=name,
-            privilege=privilege,
-            schedulable=schedulable,
-            tags=tags,
-            technique=technique,
+            attack_stage=params.get("attack_stage", attack_stage),
+            crowdstrike_expected_outcome=(EDRResponse[crwd] if crwd else None),
+            frameworks=params.get("frameworks", frameworks),
+            impact=params.get("impact", impact),
+            metadata=params.get("metadata", metadata),
+            name=params.get("name", name),
+            privilege=params.get("privilege", privilege),
+            schedulable=params.get("schedulable", schedulable),
+            tags=params.get("tags", tags),
+            technique=params.get("technique", technique),
             test_id=test,
-            unit=unit,
+            unit=params.get("unit", unit),
         )
 
 

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -41,8 +41,20 @@ def clone_test(controller, source_test_id):
 @build.command("create-test")
 @click.argument("name")
 @click.option("-a", "--attack_stage", help="attack stage")
-@click.option("--frameworks", help="framework (can be specified multiple times)", multiple=True)
+@click.option(
+    "--config",
+    help="filepath to JSON config file with test parameters (will be overridden by any CLI flags provided)",
+)
+@click.option(
+    "--frameworks", help="framework (can be specified multiple times)", multiple=True
+)
 @click.option("-i", "--impact", help="impact level", type=int)
+@click.option("-m", "--metadata", help="JSON string of additional test metadata")
+@click.option(
+    "-p",
+    "--privilege",
+    help="privilege level (e.g. privileged, unprivileged, or custom label)",
+)
 @click.option(
     "-s",
     "--schedulable",
@@ -52,15 +64,18 @@ def clone_test(controller, source_test_id):
 @click.option("--tags", help="tag (can be specified multiple times)", multiple=True)
 @click.option("-t", "--test", help="test identifier")
 @click.option("-q", "--technique", help="MITRE ATT&CK code [e.g. T1557]")
-@click.option("-u", "--unit", help="unit identifier", required=True)
+@click.option("-u", "--unit", help="unit identifier")
 @click.pass_obj
 @pretty_print
 def create_test(
     controller,
     name,
     attack_stage,
+    config,
     frameworks,
     impact,
+    metadata,
+    privilege,
     schedulable,
     tags,
     test,
@@ -88,14 +103,38 @@ def create_test(
         with open(dir, "w", encoding="utf8") as code:
             code.write(template_body)
 
+    if config and os.path.exists(config):
+        with open(config, "r") as f:
+            config_data = json.load(f)
+        name = config_data.get("name") or name
+        attack_stage = config_data.get("attack_stage") or attack_stage
+        frameworks = config_data.get("frameworks") or (
+            list(frameworks) if frameworks else None
+        )
+        impact = config_data.get("impact") or impact
+        metadata = config_data.get("metadata") or (
+            json.loads(metadata) if metadata else None
+        )
+        privilege = config_data.get("privilege") or privilege
+        schedulable = (
+            config_data.get("schedulable") if schedulable is None else schedulable
+        )
+        tags = config_data.get("tags") or (list(tags) if tags else None)
+        technique = config_data.get("technique") or technique
+        unit = config_data.get("unit") or unit
+    if not unit:
+        raise ValueError("Unit is required to create a test")
+
     with Spinner(description="Creating new test"):
         res = controller.create_test(
             name=name,
             attack_stage=attack_stage,
-            frameworks=list(frameworks) if frameworks else None,
+            frameworks=frameworks,
             impact=impact,
+            metadata=metadata,
+            privilege=privilege,
             schedulable=schedulable,
-            tags=list(tags) if tags else None,
+            tags=tags,
             test_id=test,
             technique=technique,
             unit=unit,
@@ -112,6 +151,10 @@ def create_test(
 @click.argument("test")
 @click.option("-a", "--attack_stage", help="attack stage")
 @click.option(
+    "--config",
+    help="filepath to JSON config file with test parameters (will be overridden by any CLI flags provided)",
+)
+@click.option(
     "-c",
     "--crowdstrike_expected",
     help="Crowdstrike expected outcome",
@@ -119,9 +162,17 @@ def create_test(
         [c.name for c in EDRResponse if c != EDRResponse.INVALID], case_sensitive=False
     ),
 )
-@click.option("--frameworks", help="framework (can be specified multiple times)", multiple=True)
+@click.option(
+    "--frameworks", help="framework (can be specified multiple times)", multiple=True
+)
 @click.option("-i", "--impact", help="impact level", type=int)
+@click.option("-m", "--metadata", help="JSON string of additional test metadata")
 @click.option("-n", "--name", help="test name")
+@click.option(
+    "-p",
+    "--privilege",
+    help="privilege level (e.g. privileged, unprivileged, or custom label)",
+)
 @click.option(
     "-s",
     "--schedulable",
@@ -137,27 +188,55 @@ def update_test(
     controller,
     test,
     attack_stage,
+    config,
     crowdstrike_expected,
     frameworks,
     impact,
+    metadata,
     name,
+    privilege,
     schedulable,
     tags,
     technique,
     unit,
 ):
     """Update a security test"""
+    if config and os.path.exists(config):
+        with open(config, "r") as f:
+            config_data = json.load(f)
+        name = config_data.get("name") or name
+        attack_stage = config_data.get("attack_stage") or attack_stage
+        crowdstrike_expected = (
+            config_data.get("crowdstrike_expected") or crowdstrike_expected
+        )
+        frameworks = config_data.get("frameworks") or (
+            list(frameworks) if frameworks else None
+        )
+        impact = config_data.get("impact") or impact
+        metadata = config_data.get("metadata") or (
+            json.loads(metadata) if metadata else None
+        )
+        privilege = config_data.get("privilege") or privilege
+        schedulable = (
+            config_data.get("schedulable") if schedulable is None else schedulable
+        )
+        tags = config_data.get("tags") or (list(tags) if tags else None)
+        technique = config_data.get("technique") or technique
+        unit = config_data.get("unit") or unit
+
     with Spinner(description="Updating test"):
         return controller.update_test(
             attack_stage=attack_stage,
             crowdstrike_expected_outcome=(
                 EDRResponse[crowdstrike_expected] if crowdstrike_expected else None
             ),
-            frameworks=list(frameworks) if frameworks else None,
+            frameworks=frameworks,
             impact=impact,
+            metadata=metadata,
             name=name,
+            privilege=privilege,
             schedulable=schedulable,
-            tags=list(tags) if tags else None,
+            tags=tags,
             technique=technique,
             test_id=test,
             unit=unit,

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -56,6 +56,11 @@ def clone_test(controller, source_test_id):
     help="privilege level (e.g. privileged, unprivileged, or custom label)",
 )
 @click.option(
+    "--requires_runtime",
+    help="test requires a runtime profile",
+    flag_value=True,
+)
+@click.option(
     "-s",
     "--schedulable",
     help="available to be scheduled by SCHEDULER users",
@@ -64,7 +69,9 @@ def clone_test(controller, source_test_id):
 @click.option("--tags", help="tag (can be specified multiple times)", multiple=True)
 @click.option("-t", "--test", help="test identifier")
 @click.option("-q", "--technique", help="MITRE ATT&CK code [e.g. T1557]")
+@click.option("--timeout", help="execution timeout in seconds", type=int)
 @click.option("-u", "--unit", help="unit identifier")
+@click.option("--variables", help="JSON string of runtime variables")
 @click.pass_obj
 @pretty_print
 def create_test(
@@ -76,11 +83,14 @@ def create_test(
     impact,
     metadata,
     privilege,
+    requires_runtime,
     schedulable,
     tags,
     test,
     technique,
+    timeout,
     unit,
+    variables,
 ):
     """Create a security test"""
 
@@ -106,6 +116,7 @@ def create_test(
     metadata = json.loads(metadata) if metadata else None
     frameworks = list(frameworks) if frameworks else None
     tags = list(tags) if tags else None
+    variables = json.loads(variables) if variables else None
 
     params = {}
     if config and os.path.exists(config):
@@ -119,10 +130,13 @@ def create_test(
                 impact=impact,
                 metadata=metadata,
                 privilege=privilege,
+                requires_runtime=requires_runtime,
                 schedulable=schedulable,
                 tags=tags,
                 technique=technique,
+                timeout=timeout,
                 unit=unit,
+                variables=variables,
             ).items()
             if v is not None
         }
@@ -139,11 +153,14 @@ def create_test(
             impact=params.get("impact", impact),
             metadata=params.get("metadata", metadata),
             privilege=params.get("privilege", privilege),
+            requires_runtime=params.get("requires_runtime", requires_runtime),
             schedulable=params.get("schedulable", schedulable),
             tags=params.get("tags", tags),
             test_id=test,
             technique=params.get("technique", technique),
+            timeout=params.get("timeout", timeout),
             unit=params.get("unit", unit),
+            variables=params.get("variables", variables),
         )
 
     if not test:
@@ -180,6 +197,11 @@ def create_test(
     help="privilege level (e.g. privileged, unprivileged, or custom label)",
 )
 @click.option(
+    "--requires_runtime",
+    help="test requires a runtime profile",
+    flag_value=True,
+)
+@click.option(
     "-s",
     "--schedulable",
     help="available to be scheduled by SCHEDULER users",
@@ -187,7 +209,9 @@ def create_test(
 )
 @click.option("--tags", help="tag (can be specified multiple times)", multiple=True)
 @click.option("-q", "--technique", help="MITRE ATT&CK code [e.g. T1557]")
+@click.option("--timeout", help="execution timeout in seconds", type=int)
 @click.option("-u", "--unit", help="unit identifier")
+@click.option("--variables", help="JSON string of runtime variables")
 @click.pass_obj
 @pretty_print
 def update_test(
@@ -201,15 +225,19 @@ def update_test(
     metadata,
     name,
     privilege,
+    requires_runtime,
     schedulable,
     tags,
     technique,
+    timeout,
     unit,
+    variables,
 ):
     """Update a security test"""
     metadata = json.loads(metadata) if metadata else None
     frameworks = list(frameworks) if frameworks else None
     tags = list(tags) if tags else None
+    variables = json.loads(variables) if variables else None
 
     params = {}
     if config and os.path.exists(config):
@@ -225,10 +253,13 @@ def update_test(
                 metadata=metadata,
                 name=name,
                 privilege=privilege,
+                requires_runtime=requires_runtime,
                 schedulable=schedulable,
                 tags=tags,
                 technique=technique,
+                timeout=timeout,
                 unit=unit,
+                variables=variables,
             ).items()
             if v is not None
         }
@@ -249,11 +280,14 @@ def update_test(
             metadata=params.get("metadata", metadata),
             name=params.get("name", name),
             privilege=params.get("privilege", privilege),
+            requires_runtime=params.get("requires_runtime", requires_runtime),
             schedulable=params.get("schedulable", schedulable),
             tags=params.get("tags", tags),
             technique=params.get("technique", technique),
             test_id=test,
+            timeout=params.get("timeout", timeout),
             unit=params.get("unit", unit),
+            variables=params.get("variables", variables),
         )
 
 

--- a/python/cli/prelude_cli/views/build.py
+++ b/python/cli/prelude_cli/views/build.py
@@ -56,15 +56,15 @@ def clone_test(controller, source_test_id):
     help="privilege level (e.g. privileged, unprivileged, or custom label)",
 )
 @click.option(
-    "--requires_runtime",
+    "--requires_runtime/--no-requires_runtime",
     help="test requires a runtime profile",
-    flag_value=True,
+    default=None,
 )
 @click.option(
     "-s",
-    "--schedulable",
+    "--schedulable/--no-schedulable",
     help="available to be scheduled by SCHEDULER users",
-    flag_value=True,
+    default=None,
 )
 @click.option("--tags", help="tag (can be specified multiple times)", multiple=True)
 @click.option("-t", "--test", help="test identifier")
@@ -197,15 +197,15 @@ def create_test(
     help="privilege level (e.g. privileged, unprivileged, or custom label)",
 )
 @click.option(
-    "--requires_runtime",
+    "--requires_runtime/--no-requires_runtime",
     help="test requires a runtime profile",
-    flag_value=True,
+    default=None,
 )
 @click.option(
     "-s",
-    "--schedulable",
+    "--schedulable/--no-schedulable",
     help="available to be scheduled by SCHEDULER users",
-    flag_value=True,
+    default=None,
 )
 @click.option("--tags", help="tag (can be specified multiple times)", multiple=True)
 @click.option("-q", "--technique", help="MITRE ATT&CK code [e.g. T1557]")

--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -178,12 +178,11 @@ def download(controller, test):
     """Download a test to your local environment"""
     Path(test).mkdir(parents=True, exist_ok=True)
     with Spinner(description="Downloading test"):
-        test = controller.get_test(test_id=test)
+        test_data = controller.get_test(test_id=test)
         with open(PurePath(test, "config.json"), "w") as f:
-            json.dump(test, f, indent=4)
+            json.dump(test_data, f, indent=4)
 
-        attachments = controller.get_test(test_id=test).get("attachments")
-        for attach in attachments:
+        for attach in test_data.get("attachments", []):
             code = controller.download(test_id=test, filename=attach)
             with open(PurePath(test, attach), "wb") as f:
                 f.write(code)

--- a/python/cli/prelude_cli/views/detect.py
+++ b/python/cli/prelude_cli/views/detect.py
@@ -1,5 +1,6 @@
 import asyncio
 import click
+import json
 import yaml
 
 from datetime import datetime, time, timedelta, timezone
@@ -177,8 +178,11 @@ def download(controller, test):
     """Download a test to your local environment"""
     Path(test).mkdir(parents=True, exist_ok=True)
     with Spinner(description="Downloading test"):
-        attachments = controller.get_test(test_id=test).get("attachments")
+        test = controller.get_test(test_id=test)
+        with open(PurePath(test, "config.json"), "w") as f:
+            json.dump(test, f, indent=4)
 
+        attachments = controller.get_test(test_id=test).get("attachments")
         for attach in attachments:
             code = controller.download(test_id=test, filename=attach)
             with open(PurePath(test, attach), "wb") as f:

--- a/python/sdk/prelude_sdk/controllers/build_controller.py
+++ b/python/sdk/prelude_sdk/controllers/build_controller.py
@@ -28,10 +28,13 @@ class BuildController(HttpController):
         impact=None,
         metadata=None,
         privilege=None,
+        requires_runtime=None,
         schedulable=None,
         tags=None,
         technique=None,
         test_id=None,
+        timeout=None,
+        variables=None,
     ):
         """Create or update a test"""
         body = dict(name=name, unit=unit)
@@ -45,6 +48,8 @@ class BuildController(HttpController):
             body["metadata"] = metadata
         if privilege is not None:
             body["privilege"] = privilege
+        if requires_runtime is not None:
+            body["requires_runtime"] = requires_runtime
         if schedulable is not None:
             body["schedulable"] = schedulable
         if tags is not None:
@@ -53,6 +58,10 @@ class BuildController(HttpController):
             body["technique"] = technique
         if test_id:
             body["id"] = test_id
+        if timeout is not None:
+            body["timeout"] = timeout
+        if variables is not None:
+            body["variables"] = variables
 
         res = self.post(f"{self.account.hq}/build/tests", json=body)
         return res.json()
@@ -68,10 +77,13 @@ class BuildController(HttpController):
         metadata=None,
         name=None,
         privilege=None,
+        requires_runtime=None,
         schedulable=None,
         tags=None,
         technique=None,
+        timeout=None,
         unit=None,
+        variables=None,
     ):
         """Update a test"""
         body = dict()
@@ -89,14 +101,20 @@ class BuildController(HttpController):
             body["name"] = name
         if privilege is not None:
             body["privilege"] = privilege
+        if requires_runtime is not None:
+            body["requires_runtime"] = requires_runtime
         if schedulable is not None:
             body["schedulable"] = schedulable
         if tags is not None:
             body["tags"] = tags
         if technique is not None:
             body["technique"] = technique
+        if timeout is not None:
+            body["timeout"] = timeout
         if unit:
             body["unit"] = unit
+        if variables is not None:
+            body["variables"] = variables
 
         res = self.post(f"{self.account.hq}/build/tests/{test_id}", json=body)
         return res.json()

--- a/python/sdk/prelude_sdk/controllers/build_controller.py
+++ b/python/sdk/prelude_sdk/controllers/build_controller.py
@@ -26,6 +26,8 @@ class BuildController(HttpController):
         attack_stage=None,
         frameworks=None,
         impact=None,
+        metadata=None,
+        privilege=None,
         schedulable=None,
         tags=None,
         technique=None,
@@ -39,6 +41,10 @@ class BuildController(HttpController):
             body["frameworks"] = frameworks
         if impact is not None:
             body["impact"] = impact
+        if metadata is not None:
+            body["metadata"] = metadata
+        if privilege is not None:
+            body["privilege"] = privilege
         if schedulable is not None:
             body["schedulable"] = schedulable
         if tags is not None:
@@ -59,7 +65,9 @@ class BuildController(HttpController):
         crowdstrike_expected_outcome: EDRResponse = None,
         frameworks=None,
         impact=None,
+        metadata=None,
         name=None,
+        privilege=None,
         schedulable=None,
         tags=None,
         technique=None,
@@ -75,8 +83,12 @@ class BuildController(HttpController):
             body["frameworks"] = frameworks
         if impact is not None:
             body["impact"] = impact
+        if metadata is not None:
+            body["metadata"] = metadata
         if name:
             body["name"] = name
+        if privilege is not None:
+            body["privilege"] = privilege
         if schedulable is not None:
             body["schedulable"] = schedulable
         if tags is not None:


### PR DESCRIPTION
- sdk: added new fields to create_test/update_test
- cli: added --metadata, --privilege, --requires_runtime, --timeout, --variables flags to create-test and update-test
- cli: added --config flag to create-test and update-test - reads a json config file, cli flags override config values
- cli: detect download now writes a config.json with the full test response
- cli: changed --requires_runtime and --schedulable to use flag pairs (--requires_runtime/--no-requires_runtime) so they can be explicitly set to false